### PR TITLE
Drain compatibility with Python 3.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,5 @@ target/
 Unused/
 .idea/
 POP/
-demo/.ipynb_checkpoints/
-demo/DrainEvaluation/.ipynb_checkpoints/
-logparser/Drain/.ipynb_checkpoints/
+.ipynb_checkpoints/
 *.ipynb

--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,6 @@ target/
 Unused/
 .idea/
 POP/
-*.txt
 demo/.ipynb_checkpoints/
 demo/DrainEvaluation/.ipynb_checkpoints/
 logparser/Drain/.ipynb_checkpoints/

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,8 @@ target/
 Unused/
 .idea/
 POP/
+*.txt
+demo/.ipynb_checkpoints/
+demo/DrainEvaluation/.ipynb_checkpoints/
+logparser/Drain/.ipynb_checkpoints/
+*.ipynb

--- a/demo/Drain_demo.py
+++ b/demo/Drain_demo.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys
 sys.path.append('../')
-from logparser import Drain
+from logparser.Drain import Drain
 
 input_dir  = '../logs/HDFS/'  # The input directory of log file
 output_dir = 'Drain_result/'  # The output directory of parsing results

--- a/demo/Drain_demo.py
+++ b/demo/Drain_demo.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys
 sys.path.append('../')
-from logparser.Drain import Drain
+from logparser import Drain
 
 input_dir  = '../logs/HDFS/'  # The input directory of log file
 output_dir = 'Drain_result/'  # The output directory of parsing results

--- a/logparser/Drain/Drain.py
+++ b/logparser/Drain/Drain.py
@@ -224,7 +224,7 @@ class LogParser:
 
     def printTree(self, node, dep):
         pStr = ''   
-        for i in xrange(dep):
+        for i in range(dep):
             pStr += '\t'
 
         if node.depth == 0:
@@ -234,7 +234,7 @@ class LogParser:
         else:
             pStr += node.digitOrtoken
 
-        print pStr
+        print(pStr)
 
         if node.depth == self.depth:
             return 1
@@ -273,7 +273,7 @@ class LogParser:
 
             count += 1
             if count % 1000 == 0 or count == len(self.df_log):
-                print 'Processed {0:.1f}% of log lines.'.format(count * 100.0 / len(self.df_log))
+                print('Processed {0:.1f}% of log lines.'.format(count * 100.0 / len(self.df_log)))
 
 
         if not os.path.exists(self.savePath):
@@ -320,7 +320,7 @@ class LogParser:
         regex = ''
         for k in range(len(splitters)):
             if k % 2 == 0:
-                splitter = re.sub(' +', '\s+', splitters[k])
+                splitter = re.sub(' +', '\\\s+', splitters[k])
                 regex += splitter
             else:
                 header = splitters[k].strip('<').strip('>')

--- a/logparser/Drain/__init__.py
+++ b/logparser/Drain/__init__.py
@@ -1,1 +1,1 @@
-from Drain import *
+from logparser.Drain import *

--- a/logparser/Drain/__init__.py
+++ b/logparser/Drain/__init__.py
@@ -1,1 +1,1 @@
-from logparser.Drain import *
+from .Drain import *


### PR DESCRIPTION
I have modified the Drain files in order to be compatible with Python 3.7.
Since I used a Jupyter Notebook to launch the Drain demo I modified the gitignore to ignore the different files resulting from a Notebook 