### PR TITLE
Refactoring of treeSearch function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ docs/_build/
 
 # PyBuilder
 target/
+demo/.ipynb_checkpoints/
+*.ipynb
+.idea/


### PR DESCRIPTION
I rewrite the treeSearch function in multiple functions first to have only one return per function.
And I noticed that the execution time on the evaluation came from around 0.15 second to 0.05 second.

By the way, I have added to the gitignore PyCharm files and Notebook Files