### PR TITLE
Incremental training implementation for Drain

### DIFF
--- a/demo/Drain_demo.py
+++ b/demo/Drain_demo.py
@@ -3,9 +3,12 @@ import sys
 sys.path.append('../')
 from logparser import Drain
 
+resume_training = True
+
 input_dir  = '../logs/HDFS/'  # The input directory of log file
 output_dir = 'Drain_result/'  # The output directory of parsing results
-log_file   = 'HDFS_2k.log'  # The input log file name
+history = "history"
+log_file   = 'HDFS_1k_2.log'  # The input log file name
 log_format = '<Date> <Time> <Pid> <Level> <Component>: <Content>'  # HDFS log format
 # Regular expression list for optional preprocessing (default: [])
 regex      = [
@@ -16,6 +19,6 @@ regex      = [
 st         = 0.5  # Similarity threshold
 depth      = 4  # Depth of all leaf nodes
 
-parser = Drain.LogParser(log_format, indir=input_dir, outdir=output_dir,  depth=depth, st=st, rex=regex)
+parser = Drain.LogParser(log_format, indir=input_dir, outdir=output_dir,  depth=depth, st=st, rex=regex, resume_training=resume_training, history=history)
 parser.parse(log_file)
 

--- a/demo/Drain_demo.py
+++ b/demo/Drain_demo.py
@@ -8,7 +8,7 @@ resume_training = True
 input_dir  = '../logs/HDFS/'  # The input directory of log file
 output_dir = 'Drain_result/'  # The output directory of parsing results
 history = "history"
-log_file   = 'HDFS_1k_2.log'  # The input log file name
+log_file   = 'HDFS_1k_1.log'  # The input log file name
 log_format = '<Date> <Time> <Pid> <Level> <Component>: <Content>'  # HDFS log format
 # Regular expression list for optional preprocessing (default: [])
 regex      = [

--- a/demo/Drain_demo.py
+++ b/demo/Drain_demo.py
@@ -4,7 +4,6 @@ sys.path.append('../')
 from logparser import Drain
 
 resume_training = True
-
 input_dir  = '../logs/HDFS/'  # The input directory of log file
 output_dir = 'Drain_result/'  # The output directory of parsing results
 history = "history"

--- a/logparser/Drain/Drain.py
+++ b/logparser/Drain/Drain.py
@@ -84,7 +84,7 @@ class HistoryManager:
 
 
 class Logcluster:
-    def __init__(self, logTemplate='', logIDL=None, dict_input=None):
+    def __init__(self, logTemplate='', logIDL=None):
         self.logTemplate = logTemplate
         if logIDL is None:
             logIDL = []
@@ -322,8 +322,7 @@ class LogParser:
         df_event['EventTemplate'] = templates_series.unique()
         df_event['EventId'] = df_event['EventTemplate'].map(lambda x: hashlib.md5(x.encode('utf-8')).hexdigest()[0:8])
         df_event['Occurrences'] = df_event['EventTemplate'].map(occ_dict)
-        df_event.to_csv(os.path.join(self.savePath, self.logName + '_templates.csv'), index=False,
-                        columns=["EventId", "EventTemplate", "Occurrences"])
+        df_event.to_csv(os.path.join(self.savePath, self.logName + '_templates.csv'), index=False, columns=["EventId", "EventTemplate", "Occurrences"])
 
         return len(log_templates)
 
@@ -389,10 +388,7 @@ class LogParser:
             if count % 1000 == 0 or count == len(self.df_log):
                 print('Proscessed {0:.1f}% of log lines.'.format(count * 100.0 / len(self.df_log)))
 
-        if not self.resume_training:
-            last_line_count = self.outputResult(logCluL)
-        else:
-            last_line_count = self.outputResult(logCluL, hm.lastLineCount)
+        last_line_count = self.outputResult(logCluL, hm.lastLineCount)
 
         hm.lastLineCount = last_line_count
         hm.export_history(self.history, force=not self.resume_training)
@@ -426,6 +422,7 @@ class LogParser:
         logdf.insert(0, 'LineId', None)
         logdf['LineId'] = [i + 1 for i in range(linecount)]
         return logdf
+
 
     def generate_logformat_regex(self, logformat):
         """ Function to generate regular expression to split log messages

--- a/logparser/Drain/Drain.py
+++ b/logparser/Drain/Drain.py
@@ -74,7 +74,7 @@ class HistoryManager:
         if isinstance(node['childD'], list):  # Is leaf
             logClustersList = []
             for x in node['childD']:
-                logClustersList.append(Logcluster(dict_input=x))
+                logClustersList.append(Logcluster(logTemplate=x['logTemplate'], logIDL=x['logIDL']))
             return Node(childD=logClustersList, depth=node['depth'], digitOrtoken=node['digitOrtoken'])
         else:
             temp_child_dict = dict()
@@ -85,14 +85,10 @@ class HistoryManager:
 
 class Logcluster:
     def __init__(self, logTemplate='', logIDL=None, dict_input=None):
-        if dict_input is not None:
-            self.logTemplate = dict_input['logTemplate']
-            self.logIDL = dict_input['logIDL']
-        else:
-            self.logTemplate = logTemplate
-            if logIDL is None:
-                logIDL = []
-            self.logIDL = logIDL
+        self.logTemplate = logTemplate
+        if logIDL is None:
+            logIDL = []
+        self.logIDL = logIDL
 
     def export_as_dict(self):
         return {"logIDL": self.logIDL,

--- a/logparser/Drain/Drain.py
+++ b/logparser/Drain/Drain.py
@@ -201,7 +201,15 @@ class LogParser:
         currentDepth = 1
         for token in logClust.logTemplate:
 
-            # If token not matched in this layer of existing tree.
+            #Add current log cluster to the leaf node
+            if currentDepth >= self.depth or currentDepth > seqLen:
+                if len(parentn.childD) == 0:
+                    parentn.childD = [logClust]
+                else:
+                    parentn.childD.append(logClust)
+                break
+
+            #If token not matched in this layer of existing tree. 
             if token not in parentn.childD:
                 if not self.hasNumbers(token):
                     if '<*>' in parentn.childD:
@@ -212,26 +220,26 @@ class LogParser:
                         else:
                             parentn = parentn.childD['<*>']
                     else:
-                        if len(parentn.childD) + 1 < self.maxChild:
-                            newNode = Node(depth=currentDepth + 1, digitOrtoken=token)
+                        if len(parentn.childD)+1 < self.maxChild:
+                            newNode = Node(depth=currentDepth+1, digitOrtoken=token)
                             parentn.childD[token] = newNode
                             parentn = newNode
-                        elif len(parentn.childD) + 1 == self.maxChild:
-                            newNode = Node(depth=currentDepth + 1, digitOrtoken='<*>')
+                        elif len(parentn.childD)+1 == self.maxChild:
+                            newNode = Node(depth=currentDepth+1, digitOrtoken='<*>')
                             parentn.childD['<*>'] = newNode
                             parentn = newNode
                         else:
                             parentn = parentn.childD['<*>']
-
+            
                 else:
                     if '<*>' not in parentn.childD:
-                        newNode = Node(depth=currentDepth + 1, digitOrtoken='<*>')
+                        newNode = Node(depth=currentDepth+1, digitOrtoken='<*>')
                         parentn.childD['<*>'] = newNode
                         parentn = newNode
                     else:
                         parentn = parentn.childD['<*>']
 
-            # If the token is matched
+            #If the token is matched
             else:
                 parentn = parentn.childD[token]
 
@@ -248,7 +256,7 @@ class LogParser:
                 numOfPar += 1
                 continue
             if token1 == token2:
-                simTokens += 1
+                simTokens += 1 
 
         retVal = float(simTokens) / len(seq1)
 
@@ -270,7 +278,7 @@ class LogParser:
                 maxClust = logClust
 
         if maxSim >= self.st:
-            retLogClust = maxClust
+            retLogClust = maxClust  
 
         return retLogClust
 
@@ -309,10 +317,8 @@ class LogParser:
 
         if self.keep_para:
             self.df_log["ParameterList"] = self.df_log.apply(self.get_parameter_list, axis=1)
-        structured_log_path = os.path.join(self.savePath, '{}_structured_{}.csv'.format(self.logName,
-                                                                                        datetime.now().strftime(
-                                                                                            "%Y%m%d_%H%M%S")))
-        self.df_log.to_csv(structured_log_path, index=False)
+        self.df_log.to_csv(os.path.join(self.savePath, self.logName + '_structured.csv'), index=False)
+
 
         templates_series = pd.Series(log_templates)
         occ_dict = dict(templates_series.value_counts())
@@ -326,7 +332,7 @@ class LogParser:
         return len(log_templates)
 
     def printTree(self, node, dep):
-        pStr = ''
+        pStr = ''   
         for i in range(dep):
             pStr += '\t'
 
@@ -380,7 +386,7 @@ class LogParser:
             else:
                 newTemplate = self.getTemplate(logmessageL, matchCluster.logTemplate)
                 matchCluster.logIDL.append(logID)
-                if ' '.join(newTemplate) != ' '.join(matchCluster.logTemplate):
+                if ' '.join(newTemplate) != ' '.join(matchCluster.logTemplate): 
                     matchCluster.logTemplate = newTemplate
 
             count += 1
@@ -407,7 +413,7 @@ class LogParser:
         return line
 
     def log_to_dataframe(self, log_file, regex, headers, logformat):
-        """ Function to transform log file to dataframe
+        """ Function to transform log file to dataframe 
         """
         log_messages = []
         linecount = 0

--- a/logparser/Drain/Drain.py
+++ b/logparser/Drain/Drain.py
@@ -3,7 +3,7 @@ Description : This file implements the Drain algorithm for log parsing
 Author      : LogPAI team
 License     : MIT
 """
-
+import pickle
 import re
 import os
 import numpy as np
@@ -12,12 +12,79 @@ import hashlib
 from datetime import datetime
 
 
+class HistoryManager:
+    rootNode = None
+    logCluL = None
+    rootDict = None
+    logClustersList = None
+    logTemplates = None
+    logTemplateIds = None
+
+    def __init__(self, rootNode=None, logCluL=None, history=None):
+        if history is not None:
+            self.import_history(history)
+        else:
+            self.rootNode = rootNode
+            self.logCluL = logCluL
+
+    def import_history(self, history):
+        with open(history, 'rb') as frb:
+            raw_history_data = pickle.load(frb)
+        self.rootDict = raw_history_data["rootDict"]
+        self.logClustersList = raw_history_data["logClustersList"]
+        self.logTemplates = raw_history_data["logTemplates"]
+        self.logTemplateIds = raw_history_data["logTemplateIds"]
+        self.recreate_tree()
+        self.recreate_log_clusters()
+
+    def export_history(self, history, force=False):
+        if os.path.exists(history) and not force:
+            if os.path.exists(history + "_backup"):
+                os.remove(history + "_backup")
+            os.rename(history, history + "_backup")
+        raw_history_data = {'rootDict': self.rootNode.export_as_dict(),
+                            'logClustersList': [x.export_as_dict() for x in self.logCluL],
+                            'logTemplates': self.logTemplates,
+                            'logTemplateIds': self.logTemplateIds}
+        with open(history, 'wb') as fwb:
+            pickle.dump(raw_history_data, fwb)
+
+    def recreate_log_clusters(self):
+        logClustersList = []
+        for x in self.logClustersList:
+            logClustersList.append(Logcluster(dict_input=x))
+        self.logCluL = logClustersList
+
+    def recreate_tree(self):
+        self.rootNode = self.recursive_subroutine_recreate_tree(self.rootDict)
+
+    def recursive_subroutine_recreate_tree(self, node):
+        if isinstance(node['childD'], list):  # Is leaf
+            logClustersList = []
+            for x in node['childD']:
+                logClustersList.append(Logcluster(dict_input=x))
+            return Node(childD=logClustersList, depth=node['depth'], digitOrtoken=node['digitOrtoken'])
+        else:
+            temp_child_dict = dict()
+            for child_id, child_item in node['childD'].items():
+                temp_child_dict[child_id] = self.recursive_subroutine_recreate_tree(child_item)
+            return Node(childD=temp_child_dict, depth=node['depth'], digitOrtoken=node['digitOrtoken'])
+
+
 class Logcluster:
-    def __init__(self, logTemplate='', logIDL=None):
-        self.logTemplate = logTemplate
-        if logIDL is None:
-            logIDL = []
-        self.logIDL = logIDL
+    def __init__(self, logTemplate='', logIDL=None, dict_input=None):
+        if dict_input is not None:
+            self.logTemplate = dict_input['logTemplate']
+            self.logIDL = dict_input['logIDL']
+        else:
+            self.logTemplate = logTemplate
+            if logIDL is None:
+                logIDL = []
+            self.logIDL = logIDL
+
+    def export_as_dict(self):
+        return {"logIDL": self.logIDL,
+                "logTemplate": self.logTemplate}
 
 
 class Node:
@@ -28,10 +95,23 @@ class Node:
         self.depth = depth
         self.digitOrtoken = digitOrtoken
 
+    def export_as_dict(self):
+        if isinstance(self.childD, list):  # Is leaf
+            return {"depth": self.depth,
+                    "digitOrtoken": self.digitOrtoken,
+                    "childD": [x.export_as_dict() for x in self.childD]}
+        else:
+            temp_child_dict = dict()
+            for child_id, child_item in self.childD.items():
+                temp_child_dict[child_id] = child_item.export_as_dict()
+            return {"depth": self.depth,
+                    "digitOrtoken": self.digitOrtoken,
+                    "childD": temp_child_dict}
+
 
 class LogParser:
-    def __init__(self, log_format, indir='./', outdir='./result/', depth=4, st=0.4, 
-                 maxChild=100, rex=[], keep_para=True):
+    def __init__(self, log_format, indir='./', outdir='./result/', depth=4, st=0.4,
+                 maxChild=100, rex=[], keep_para=True, resume_training=False, history="history"):
         """
         Attributes
         ----------
@@ -42,6 +122,8 @@ class LogParser:
             maxChild : max number of children of an internal node
             logName : the name of the input file containing raw log messages
             savePath : the output path stores the file containing structured logs
+            resume_training : True to continue training from an existing history, history must not be None
+            history : history file name to continue training model, will be appended to outdir to get full file path
         """
         self.path = indir
         self.depth = depth - 2
@@ -53,6 +135,15 @@ class LogParser:
         self.log_format = log_format
         self.rex = rex
         self.keep_para = keep_para
+        self.history = os.path.join(outdir, history)
+        self.resume_training = resume_training
+        if not os.path.exists(outdir):
+            os.makedirs(outdir)
+        if resume_training:
+            if not os.path.exists(self.history):
+                print("No history found at {} to resume training!".format(self.history))
+                print("Starting training from scratch")
+                self.resume_training = False
 
     def hasNumbers(self, s):
         return any(char.isdigit() for char in s)
@@ -98,7 +189,7 @@ class LogParser:
         currentDepth = 1
         for token in logClust.logTemplate:
 
-            #Add current log cluster to the leaf node
+            # Add current log cluster to the leaf node
             if currentDepth >= self.depth or currentDepth > seqLen:
                 if len(parentn.childD) == 0:
                     parentn.childD = [logClust]
@@ -106,7 +197,7 @@ class LogParser:
                     parentn.childD.append(logClust)
                 break
 
-            #If token not matched in this layer of existing tree. 
+            # If token not matched in this layer of existing tree.
             if token not in parentn.childD:
                 if not self.hasNumbers(token):
                     if '<*>' in parentn.childD:
@@ -117,32 +208,32 @@ class LogParser:
                         else:
                             parentn = parentn.childD['<*>']
                     else:
-                        if len(parentn.childD)+1 < self.maxChild:
-                            newNode = Node(depth=currentDepth+1, digitOrtoken=token)
+                        if len(parentn.childD) + 1 < self.maxChild:
+                            newNode = Node(depth=currentDepth + 1, digitOrtoken=token)
                             parentn.childD[token] = newNode
                             parentn = newNode
-                        elif len(parentn.childD)+1 == self.maxChild:
-                            newNode = Node(depth=currentDepth+1, digitOrtoken='<*>')
+                        elif len(parentn.childD) + 1 == self.maxChild:
+                            newNode = Node(depth=currentDepth + 1, digitOrtoken='<*>')
                             parentn.childD['<*>'] = newNode
                             parentn = newNode
                         else:
                             parentn = parentn.childD['<*>']
-            
+
                 else:
                     if '<*>' not in parentn.childD:
-                        newNode = Node(depth=currentDepth+1, digitOrtoken='<*>')
+                        newNode = Node(depth=currentDepth + 1, digitOrtoken='<*>')
                         parentn.childD['<*>'] = newNode
                         parentn = newNode
                     else:
                         parentn = parentn.childD['<*>']
 
-            #If the token is matched
+            # If the token is matched
             else:
                 parentn = parentn.childD[token]
 
             currentDepth += 1
 
-    #seq1 is template
+    # seq1 is template
     def seqDist(self, seq1, seq2):
         assert len(seq1) == len(seq2)
         simTokens = 0
@@ -153,12 +244,11 @@ class LogParser:
                 numOfPar += 1
                 continue
             if token1 == token2:
-                simTokens += 1 
+                simTokens += 1
 
         retVal = float(simTokens) / len(seq1)
 
         return retVal, numOfPar
-
 
     def fastMatch(self, logClustL, seq):
         retLogClust = None
@@ -169,13 +259,13 @@ class LogParser:
 
         for logClust in logClustL:
             curSim, curNumOfPara = self.seqDist(logClust.logTemplate, seq)
-            if curSim>maxSim or (curSim==maxSim and curNumOfPara>maxNumOfPara):
+            if curSim > maxSim or (curSim == maxSim and curNumOfPara > maxNumOfPara):
                 maxSim = curSim
                 maxNumOfPara = curNumOfPara
                 maxClust = logClust
 
         if maxSim >= self.st:
-            retLogClust = maxClust  
+            retLogClust = maxClust
 
         return retLogClust
 
@@ -194,109 +284,17 @@ class LogParser:
 
         return retVal
 
-    def outputResult(self, logClustL):
-        log_templates = [0] * self.df_log.shape[0]
-        log_templateids = [0] * self.df_log.shape[0]
-        df_events = []
-        for logClust in logClustL:
-            template_str = ' '.join(logClust.logTemplate)
-            occurrence = len(logClust.logIDL)
-            template_id = hashlib.md5(template_str.encode('utf-8')).hexdigest()[0:8]
-            for logID in logClust.logIDL:
-                logID -= 1
-                log_templates[logID] = template_str
-                log_templateids[logID] = template_id
-            df_events.append([template_id, template_str, occurrence])
-
-        df_event = pd.DataFrame(df_events, columns=['EventId', 'EventTemplate', 'Occurrences'])
-        self.df_log['EventId'] = log_templateids
-        self.df_log['EventTemplate'] = log_templates
-
-        if self.keep_para:
-            self.df_log["ParameterList"] = self.df_log.apply(self.get_parameter_list, axis=1) 
-        self.df_log.to_csv(os.path.join(self.savePath, self.logName + '_structured.csv'), index=False)
-
-
-        occ_dict = dict(self.df_log['EventTemplate'].value_counts())
-        df_event = pd.DataFrame()
-        df_event['EventTemplate'] = self.df_log['EventTemplate'].unique()
-        df_event['EventId'] = df_event['EventTemplate'].map(lambda x: hashlib.md5(x.encode('utf-8')).hexdigest()[0:8])
-        df_event['Occurrences'] = df_event['EventTemplate'].map(occ_dict)
-        df_event.to_csv(os.path.join(self.savePath, self.logName + '_templates.csv'), index=False, columns=["EventId", "EventTemplate", "Occurrences"])
-
-
-    def printTree(self, node, dep):
-        pStr = ''   
-        for i in range(dep):
-            pStr += '\t'
-
-        if node.depth == 0:
-            pStr += 'Root'
-        elif node.depth == 1:
-            pStr += '<' + str(node.digitOrtoken) + '>'
-        else:
-            pStr += node.digitOrtoken
-
-        print(pStr)
-
-        if node.depth == self.depth:
-            return 1
-        for child in node.childD:
-            self.printTree(node.childD[child], dep+1)
-
-
-    def parse(self, logName):
-        print('Parsing file: ' + os.path.join(self.path, logName))
-        start_time = datetime.now()
-        self.logName = logName
-        rootNode = Node()
-        logCluL = []
-
-        self.load_data()
-
-        count = 0
-        for idx, line in self.df_log.iterrows():
-            logID = line['LineId']
-            logmessageL = self.preprocess(line['Content']).strip().split()
-            # logmessageL = filter(lambda x: x != '', re.split('[\s=:,]', self.preprocess(line['Content'])))
-            matchCluster = self.treeSearch(rootNode, logmessageL)
-
-            #Match no existing log cluster
-            if matchCluster is None:
-                newCluster = Logcluster(logTemplate=logmessageL, logIDL=[logID])
-                logCluL.append(newCluster)
-                self.addSeqToPrefixTree(rootNode, newCluster)
-
-            #Add the new log message to the existing cluster
-            else:
-                newTemplate = self.getTemplate(logmessageL, matchCluster.logTemplate)
-                matchCluster.logIDL.append(logID)
-                if ' '.join(newTemplate) != ' '.join(matchCluster.logTemplate): 
-                    matchCluster.logTemplate = newTemplate
-
-            count += 1
-            if count % 1000 == 0 or count == len(self.df_log):
-                print('Processed {0:.1f}% of log lines.'.format(count * 100.0 / len(self.df_log)))
-
-
-        if not os.path.exists(self.savePath):
-            os.makedirs(self.savePath)
-
-        self.outputResult(logCluL)
-
-        print('Parsing done. [Time taken: {!s}]'.format(datetime.now() - start_time))
-
     def load_data(self):
         headers, regex = self.generate_logformat_regex(self.log_format)
-        self.df_log = self.log_to_dataframe(os.path.join(self.path, self.logName), regex, headers, self.log_format)
+        self.df_log = self.log_to_dataframe(os.path.join(self.path, self.logName), regex, headers)
 
     def preprocess(self, line):
         for currentRex in self.rex:
             line = re.sub(currentRex, '<*>', line)
         return line
 
-    def log_to_dataframe(self, log_file, regex, headers, logformat):
-        """ Function to transform log file to dataframe 
+    def log_to_dataframe(self, log_file, regex, headers):
+        """ Function to transform log file to dataframe
         """
         log_messages = []
         linecount = 0
@@ -313,7 +311,6 @@ class LogParser:
         logdf.insert(0, 'LineId', None)
         logdf['LineId'] = [i + 1 for i in range(linecount)]
         return logdf
-
 
     def generate_logformat_regex(self, logformat):
         """ Function to generate regular expression to split log messages
@@ -342,3 +339,116 @@ class LogParser:
         parameter_list = parameter_list[0] if parameter_list else ()
         parameter_list = list(parameter_list) if isinstance(parameter_list, tuple) else [parameter_list]
         return parameter_list
+
+    def parse(self, logName):
+        print('Parsing file: ' + os.path.join(self.path, logName))
+        start_time = datetime.now()
+        self.logName = logName
+
+        if self.resume_training:
+            hm = HistoryManager(history=self.history)
+            hm.import_history(self.history)
+            rootNode = hm.rootNode
+            logCluL = hm.logCluL
+        else:
+            rootNode = Node()
+            logCluL = []
+            hm = HistoryManager(rootNode=rootNode, logCluL=logCluL)
+
+        self.load_data()
+
+        count = 0
+        last_line = 0 if hm.logTemplates is None else len(hm.logTemplates)
+        for idx, line in self.df_log.iterrows():
+            logID = line['LineId'] + last_line
+            logmessageL = self.preprocess(line['Content']).strip().split()
+            # logmessageL = filter(lambda x: x != '', re.split('[\s=:,]', self.preprocess(line['Content'])))
+            matchCluster = self.treeSearch(rootNode, logmessageL)
+
+            # Match no existing log cluster
+            if matchCluster is None:
+                newCluster = Logcluster(logTemplate=logmessageL, logIDL=[logID])
+                logCluL.append(newCluster)
+                self.addSeqToPrefixTree(rootNode, newCluster)
+
+            # Add the new log message to the existing cluster
+            else:
+                newTemplate = self.getTemplate(logmessageL, matchCluster.logTemplate)
+                matchCluster.logIDL.append(logID)
+                if ' '.join(newTemplate) != ' '.join(matchCluster.logTemplate):
+                    matchCluster.logTemplate = newTemplate
+
+            count += 1
+            if count % 1000 == 0 or count == len(self.df_log):
+                print('Proscessed {0:.1f}% of log lines.'.format(count * 100.0 / len(self.df_log)))
+
+        if not self.resume_training:
+            log_templates, log_templateids = self.outputResult(logCluL)
+        else:
+            log_templates, log_templateids = self.outputResult(logCluL, hm.logTemplates, hm.logTemplateIds)
+
+        hm.logTemplates = log_templates
+        hm.logTemplateIds = log_templateids
+        hm.export_history(self.history, force=not self.resume_training)
+
+        print('Parsing done. [Time taken: {!s}]'.format(datetime.now() - start_time))
+
+    def outputResult(self, logClustL, old_log_templates=None, old_log_templateids=None):
+        if old_log_templates is None or old_log_templateids is None:
+            log_templates = list()
+            log_templateids = list()
+        else:
+            log_templates = old_log_templates
+            log_templateids = old_log_templateids
+        log_templates = log_templates + [0] * self.df_log.shape[0]
+        log_templateids = log_templateids + [0] * self.df_log.shape[0]
+
+        offset = -1
+
+        for logClust in logClustL:
+            template_str = ' '.join(logClust.logTemplate)
+            template_id = hashlib.md5(template_str.encode('utf-8')).hexdigest()[0:8]
+            for logID in logClust.logIDL:
+                logID += offset
+                log_templates[logID] = template_str
+                log_templateids[logID] = template_id
+
+        self.df_log['EventId'] = log_templateids[-self.df_log.shape[0]:]
+        self.df_log['EventTemplate'] = log_templates[-self.df_log.shape[0]:]
+
+        if self.keep_para:
+            self.df_log["ParameterList"] = self.df_log.apply(self.get_parameter_list, axis=1)
+        structured_log_path = os.path.join(self.savePath, '{}_structured_{}.csv'.format(self.logName,
+                                                                                        datetime.now().strftime(
+                                                                                            "%Y%m%d_%H%M%S")))
+        self.df_log.to_csv(structured_log_path, index=False)
+
+        templates_series = pd.Series(log_templates)
+        templates_series_count = dict(templates_series.value_counts())
+        df_event = pd.DataFrame()
+        df_event['EventTemplate'] = templates_series.unique()
+        df_event['EventId'] = df_event['EventTemplate'].map(lambda x: hashlib.md5(x.encode('utf-8')).hexdigest()[0:8])
+        df_event['Occurrences'] = df_event['EventTemplate'].map(templates_series_count)
+        df_event.to_csv(os.path.join(self.savePath, self.logName + '_templates.csv'), index=False,
+                        columns=["EventId", "EventTemplate", "Occurrences"])
+
+        return log_templates, log_templateids
+
+    def printTree(self, node, dep):
+        pStr = ''
+        for i in range(dep):
+            pStr += '\t'
+
+        if node.depth == 0:
+            pStr += 'Root'
+        elif node.depth == 1:
+            pStr += '<' + str(node.digitOrtoken) + '>'
+        else:
+            pStr += node.digitOrtoken
+
+        print(pStr)
+
+        if node.depth == self.depth:
+            return 1
+        for child in node.childD:
+            self.printTree(node.childD[child], dep + 1)

--- a/logs/HDFS/HDFS_1k_1.log
+++ b/logs/HDFS/HDFS_1k_1.log
@@ -1,0 +1,1000 @@
+081109 203615 148 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_38865049064139660 terminating
+081109 203807 222 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-6952295868487656571 terminating
+081109 204005 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.73.220:50010 is added to blk_7128370237687728475 size 67108864
+081109 204015 308 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_8229193803249955061 terminating
+081109 204106 329 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-6670958622368987959 terminating
+081109 204132 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.43.115:50010 is added to blk_3050920587428079149 size 67108864
+081109 204324 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.203.80:50010 is added to blk_7888946331804732825 size 67108864
+081109 204453 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.11.85:50010 is added to blk_2377150260128098806 size 67108864
+081109 204525 512 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_572492839287299681 terminating
+081109 204655 556 INFO dfs.DataNode$PacketResponder: Received block blk_3587508140051953248 of size 67108864 from /10.251.42.84
+081109 204722 567 INFO dfs.DataNode$PacketResponder: Received block blk_5402003568334525940 of size 67108864 from /10.251.214.112
+081109 204815 653 INFO dfs.DataNode$DataXceiver: Receiving block blk_5792489080791696128 src: /10.251.30.6:33145 dest: /10.251.30.6:50010
+081109 204842 663 INFO dfs.DataNode$DataXceiver: Receiving block blk_1724757848743533110 src: /10.251.111.130:49851 dest: /10.251.111.130:50010
+081109 204908 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.110.8:50010 is added to blk_8015913224713045110 size 67108864
+081109 204925 673 INFO dfs.DataNode$DataXceiver: Receiving block blk_-5623176793330377570 src: /10.251.75.228:53725 dest: /10.251.75.228:50010
+081109 205035 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand/_temporary/_task_200811092030_0001_m_000590_0/part-00590. blk_-1727475099218615100
+081109 205056 710 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_5017373558217225674 terminating
+081109 205157 752 INFO dfs.DataNode$PacketResponder: Received block blk_9212264480425680329 of size 67108864 from /10.251.123.1
+081109 205315 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand/_temporary/_task_200811092030_0001_m_000742_0/part-00742. blk_-7878121102358435702
+081109 205409 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.111.130:50010 is added to blk_4568434182693165548 size 67108864
+081109 205412 832 INFO dfs.DataNode$PacketResponder: Received block blk_-5704899712662113150 of size 67108864 from /10.251.91.229
+081109 205632 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.74.79:50010 is added to blk_-4794867979917102672 size 67108864
+081109 205739 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.38.197:50010 is added to blk_8763662564934652249 size 67108864
+081109 205742 1001 INFO dfs.DataNode$PacketResponder: Received block blk_-5861636720645142679 of size 67108864 from /10.251.70.211
+081109 205746 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.74.134:50010 is added to blk_7453815855294711849 size 67108864
+081109 205749 997 INFO dfs.DataNode$DataXceiver: Receiving block blk_-28342503914935090 src: /10.251.123.132:57542 dest: /10.251.123.132:50010
+081109 205754 952 INFO dfs.DataNode$PacketResponder: Received block blk_8291449241650212794 of size 67108864 from /10.251.89.155
+081109 205858 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand/_temporary/_task_200811092030_0001_m_000487_0/part-00487. blk_-5319073033164653435
+081109 205931 13 INFO dfs.DataBlockScanner: Verification succeeded for blk_-4980916519894289629
+081109 210022 1110 INFO dfs.DataNode$PacketResponder: Received block blk_-5974833545991408899 of size 67108864 from /10.251.31.180
+081109 210037 1084 INFO dfs.DataNode$DataXceiver: Receiving block blk_-5009020203888190378 src: /10.251.199.19:52622 dest: /10.251.199.19:50010
+081109 210248 1138 INFO dfs.DataNode$PacketResponder: Received block blk_6921674711959888070 of size 67108864 from /10.251.65.203
+081109 210407 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.7.244:50010 is added to blk_5165786360127153975 size 67108864
+081109 210458 1278 INFO dfs.DataNode$DataXceiver: Receiving block blk_2937758977269298350 src: /10.251.194.129:37476 dest: /10.251.194.129:50010
+081109 210551 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.6.191:50010 is added to blk_673825774073966710 size 67108864
+081109 210637 1283 INFO dfs.DataNode$PacketResponder: Received block blk_-7526945448667194862 of size 67108864 from /10.251.203.80
+081109 210656 1334 INFO dfs.DataNode$PacketResponder: Received block blk_-2094397855762091248 of size 67108864 from /10.251.126.83
+081109 210712 1333 INFO dfs.DataNode$PacketResponder: Received block blk_-8523968015014407246 of size 67108864 from /10.251.214.225
+081109 210743 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.89.155:50010 is added to blk_8181993091797661153 size 67108864
+081109 210801 1357 INFO dfs.DataNode$DataXceiver: Receiving block blk_-6276023454199613372 src: /10.251.65.237:34085 dest: /10.251.65.237:50010
+081109 210807 1408 INFO dfs.DataNode$PacketResponder: Received block blk_4755566011267050000 of size 67108864 from /10.251.75.79
+081109 210812 1395 INFO dfs.DataNode$PacketResponder: Received block blk_-3909548841543565741 of size 3542967 from /10.251.195.33
+081109 210921 1452 INFO dfs.DataNode$DataXceiver: Receiving block blk_-6809181994368905854 src: /10.250.17.225:51754 dest: /10.250.17.225:50010
+081109 210935 1458 INFO dfs.DataNode$PacketResponder: Received block blk_8829027411458566099 of size 67108864 from /10.251.38.214
+081109 211029 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.106.50:50010 is added to blk_-29548654251973735 size 67108864
+081109 211038 1490 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-5073870177832699716 terminating
+081109 211216 1504 INFO dfs.DataNode$PacketResponder: Received block blk_-8241093737585222406 of size 67108864 from /10.250.5.161
+081109 211301 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.111.228:50010 is added to blk_-2480595760294717232 size 67108864
+081109 211353 1574 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_7791237942696729620 terminating
+081109 211403 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.202.134:50010 is added to blk_2113880130496815041 size 3549917
+081109 211453 1623 INFO dfs.DataNode$PacketResponder: Received block blk_1064470652608359218 of size 67108864 from /10.251.39.242
+081109 211528 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.110.8:50010 is added to blk_-1661553043410372067 size 67108864
+081109 211617 1635 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-1527267659500322006 terminating
+081109 211918 1777 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_4886940526690879848 terminating
+081109 212029 1814 INFO dfs.DataNode$PacketResponder: Received block blk_-2452477352812192142 of size 67108864 from /10.250.7.244
+081109 212219 1885 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-4229375751333894621 terminating
+081109 212220 1946 INFO dfs.DataNode$DataXceiver: Receiving block blk_-774267833966018354 src: /10.251.38.53:51057 dest: /10.251.38.53:50010
+081109 212245 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand/_temporary/_task_200811092030_0001_m_001648_0/part-01648. blk_2513940824125131775
+081109 212317 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand/_temporary/_task_200811092030_0001_m_001866_0/part-01866. blk_-1282453782148343691
+081109 212338 2007 INFO dfs.DataNode$PacketResponder: Received block blk_-518701095493827363 of size 67108864 from /10.251.214.67
+081109 212403 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.106.50:50010 is added to blk_-2530087534157630851 size 67108864
+081109 212440 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.198.196:50010 is added to blk_427714267500527780 size 67108864
+081109 212703 2053 INFO dfs.DataNode$PacketResponder: Received block blk_-967145856473901804 of size 67108864 from /10.250.6.191
+081109 212904 2174 INFO dfs.DataNode$PacketResponder: Received block blk_8408125361497769001 of size 67108864 from /10.251.70.211
+081109 212931 2211 INFO dfs.DataNode$PacketResponder: Received block blk_-1614641487214609125 of size 67108864 from /10.251.193.175
+081109 213009 2207 INFO dfs.DataNode$PacketResponder: Received block blk_7577595658377008671 of size 67108864 from /10.251.71.97
+081109 213028 2206 INFO dfs.DataNode$PacketResponder: Received block blk_3777400576053320362 of size 67108864 from /10.251.31.5
+081109 213217 2267 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-5852844080027817147 terminating
+081109 213353 2313 INFO dfs.DataNode$PacketResponder: Received block blk_-2129171714384027465 of size 67108864 from /10.251.75.228
+081109 213436 13 INFO dfs.DataBlockScanner: Verification succeeded for blk_-2827716238972737794
+081109 213506 2421 INFO dfs.DataNode$DataXceiver: Receiving block blk_-3509323198988774369 src: /10.250.6.214:52922 dest: /10.250.6.214:50010
+081109 213510 2384 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_9093049293972551787 terminating
+081109 213837 19 INFO dfs.FSDataset: Deleting block blk_1781953582842324563 file /mnt/hadoop/dfs/data/current/subdir5/blk_1781953582842324563
+081109 213847 2552 INFO dfs.DataNode$DataXceiver: 10.251.194.213:50010 Served block blk_-7724713468912166542 to /10.251.203.80
+081109 213907 2497 INFO dfs.DataNode$DataXceiver: 10.251.91.229:50010 Served block blk_-3358448553918665902 to /10.251.91.229
+081109 213908 2549 INFO dfs.DataNode$DataXceiver: 10.251.39.192:50010 Served block blk_-5341992729755584578 to /10.251.39.192
+081109 214009 2594 INFO dfs.DataNode$DataXceiver: 10.250.5.237:50010 Served block blk_3166960787499091856 to /10.251.43.147
+081109 214043 2561 WARN dfs.DataNode$DataXceiver: 10.251.30.85:50010:Got exception while serving blk_-2918118818249673980 to /10.251.90.64:
+081109 214402 2677 WARN dfs.DataNode$DataXceiver: 10.251.126.255:50010:Got exception while serving blk_8376667364205250596 to /10.251.91.159:
+081109 214524 2633 INFO dfs.DataNode$DataXceiver: 10.251.71.68:50010 Served block blk_-2794533871450434534 to /10.251.199.150
+081109 214529 2747 WARN dfs.DataNode$DataXceiver: 10.251.123.132:50010:Got exception while serving blk_3763728533434719668 to /10.251.38.214:
+081109 214910 2848 WARN dfs.DataNode$DataXceiver: 10.250.13.188:50010:Got exception while serving blk_6241141267506413726 to /10.251.194.245:
+081109 214919 2899 INFO dfs.DataNode$DataXceiver: 10.251.214.32:50010 Served block blk_-6520030462660619051 to /10.251.215.70
+081109 215136 2868 WARN dfs.DataNode$DataXceiver: 10.251.199.19:50010:Got exception while serving blk_8466246428293623262 to /10.251.106.37:
+081109 215259 2934 WARN dfs.DataNode$DataXceiver: 10.250.9.207:50010:Got exception while serving blk_-3140754468249228022 to /10.250.9.207:
+081109 215702 3022 WARN dfs.DataNode$DataXceiver: 10.251.202.134:50010:Got exception while serving blk_3441699978641526775 to /10.251.126.5:
+081109 215734 3055 INFO dfs.DataNode$DataXceiver: 10.250.6.214:50010 Served block blk_5739119717322549945 to /10.251.43.115
+081109 220032 3137 WARN dfs.DataNode$DataXceiver: 10.250.14.196:50010:Got exception while serving blk_-305633040016166849 to /10.251.38.53:
+081109 220403 3148 WARN dfs.DataNode$DataXceiver: 10.251.107.227:50010:Got exception while serving blk_-6290631608800952376 to /10.251.109.209:
+081109 220528 3174 INFO dfs.DataNode$DataXceiver: 10.251.203.166:50010 Served block blk_8787656642683881295 to /10.251.107.98
+081109 221105 3338 WARN dfs.DataNode$DataXceiver: 10.251.90.64:50010:Got exception while serving blk_-4841792440390267307 to /10.251.90.239:
+081109 221151 3361 WARN dfs.DataNode$DataXceiver: 10.250.10.144:50010:Got exception while serving blk_5126469776250053435 to /10.250.11.100:
+081109 222040 3463 WARN dfs.DataNode$DataXceiver: 10.251.71.146:50010:Got exception while serving blk_-2032740670708110312 to /10.251.197.161:
+081109 222041 3390 WARN dfs.DataNode$DataXceiver: 10.251.67.113:50010:Got exception while serving blk_-62891505109755100 to /10.250.7.96:
+081109 222342 3462 WARN dfs.DataNode$DataXceiver: 10.251.74.79:50010:Got exception while serving blk_2244903517044280975 to /10.251.74.134:
+081109 222650 3459 WARN dfs.DataNode$DataXceiver: 10.251.214.112:50010:Got exception while serving blk_5905933788014151041 to /10.251.214.112:
+081109 223211 3544 INFO dfs.DataNode$DataXceiver: 10.251.111.80:50010 Served block blk_6296828743242110158 to /10.251.42.246
+081109 223910 3540 WARN dfs.DataNode$DataXceiver: 10.251.43.210:50010:Got exception while serving blk_2969087638814291714 to /10.251.199.86:
+081109 224054 3560 WARN dfs.DataNode$DataXceiver: 10.251.126.255:50010:Got exception while serving blk_2879780987351022871 to /10.251.39.144:
+081109 224234 3638 WARN dfs.DataNode$DataXceiver: 10.251.73.220:50010:Got exception while serving blk_4934527196392001803 to /10.251.203.246:
+081109 224420 3666 WARN dfs.DataNode$DataXceiver: 10.251.73.188:50010:Got exception while serving blk_7517964792804498202 to /10.250.6.191:
+081109 224741 3699 WARN dfs.DataNode$DataXceiver: 10.251.35.1:50010:Got exception while serving blk_7940316270494947483 to /10.251.122.38:
+081109 230110 3647 WARN dfs.DataNode$DataXceiver: 10.251.90.134:50010:Got exception while serving blk_7154985168984871115 to /10.251.110.160:
+081109 232200 3856 INFO dfs.DataNode$PacketResponder: Received block blk_-6867873931012347356 of size 67108864 from /10.251.39.64
+081109 232324 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.107.19:50010 is added to blk_6093743385844975689 size 67108864
+081109 232346 3820 INFO dfs.DataNode$DataXceiver: Receiving block blk_8692428775973608797 src: /10.250.10.213:56574 dest: /10.250.10.213:50010
+081109 232639 3792 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-6837050820114491742 terminating
+081109 232828 3875 INFO dfs.DataNode$PacketResponder: Received block blk_-5195432543794777448 of size 67108864 from /10.250.10.6
+081109 232829 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.110.68:50010 is added to blk_1636660629634995787 size 67108864
+081109 232833 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.75.79:50010 is added to blk_467589865104023338 size 67108864
+081109 232923 3792 INFO dfs.DataNode$PacketResponder: Received block blk_7929144620252342335 of size 67108864 from /10.251.31.5
+081109 232926 3783 INFO dfs.DataNode$DataXceiver: Receiving block blk_-1798958443298220150 src: /10.251.111.209:57419 dest: /10.251.111.209:50010
+081109 233108 3872 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-54240672253074715 terminating
+081109 233356 3917 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7172347691639518373 src: /10.251.111.37:35327 dest: /10.251.111.37:50010
+081109 233753 3950 INFO dfs.DataNode$DataXceiver: Receiving block blk_-6412155847905320411 src: /10.251.30.85:58995 dest: /10.251.30.85:50010
+081109 233835 4139 INFO dfs.DataNode$DataXceiver: Receiving block blk_699651392443620263 src: /10.251.70.5:34703 dest: /10.251.70.5:50010
+081109 233836 4061 INFO dfs.DataNode$DataXceiver: Receiving block blk_-8788032532930439012 src: /10.251.126.255:41104 dest: /10.251.126.255:50010
+081109 233849 4087 INFO dfs.DataNode$PacketResponder: Received block blk_-3455521536483250153 of size 67108864 from /10.251.106.37
+081109 234027 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.31.85:50010 is added to blk_-7017553867379051457 size 67108864
+081109 234107 4261 INFO dfs.DataNode$DataXceiver: Receiving block blk_-1259190292740306590 src: /10.251.65.203:36289 dest: /10.251.65.203:50010
+081109 234110 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/sortrand/_temporary/_task_200811092030_0002_r_000296_0/part-00296. blk_-6620182933895093708
+081109 234111 4288 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_2028803850179311599 terminating
+081109 234112 4136 INFO dfs.DataNode$DataXceiver: Receiving block blk_-8562334328670278932 src: /10.251.194.147:46714 dest: /10.251.194.147:50010
+081109 234325 4246 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-8108913101671416218 terminating
+081109 234512 4223 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-7640601843607665080 terminating
+081109 234516 4136 INFO dfs.DataNode$DataXceiver: Receiving block blk_7654726977769174867 src: /10.251.110.160:49990 dest: /10.251.110.160:50010
+081109 234555 4345 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_8320088109701056055 terminating
+081109 234605 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.197.226:50010 is added to blk_4585055992495043771 size 67108864
+081109 234644 4177 INFO dfs.DataNode$PacketResponder: Received block blk_-4330512786228504138 of size 67108864 from /10.251.67.225
+081109 234706 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.30.179:50010 is added to blk_4628142183191390143 size 67108864
+081109 234719 4344 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-6766351519628312408 terminating
+081109 234728 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.5.237:50010 is added to blk_-476906696485288376 size 67108864
+081109 234835 3972 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-7436749154361133879 terminating
+081109 234835 4259 INFO dfs.DataNode$DataXceiver: Receiving block blk_7061131805920430446 src: /10.250.7.32:53397 dest: /10.250.7.32:50010
+081109 234924 4275 INFO dfs.DataNode$PacketResponder: Received block blk_-684595390732854503 of size 67108864 from /10.250.6.191
+081109 235030 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.7.244:50010 is added to blk_-6956067134432991406 size 67108864
+081109 235138 3469 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_549647953114643908 terminating
+081109 235140 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/sortrand/_temporary/_task_200811092030_0002_r_000230_0/part-00230. blk_559204981722276126
+081109 235305 4419 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-165500353496111884 terminating
+081109 235311 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/sortrand/_temporary/_task_200811092030_0002_r_000169_0/part-00169. blk_-7105305952901940477
+081109 235322 3968 INFO dfs.DataNode$DataXceiver: Receiving block blk_-9103764593642564543 src: /10.251.43.115:46385 dest: /10.251.43.115:50010
+081109 235337 4459 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_3160319368100972992 terminating
+081109 235426 4327 INFO dfs.DataNode$PacketResponder: Received block blk_-562725280853087685 of size 67108864 from /10.251.91.84
+081109 235609 4400 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_4568377692254637284 terminating
+081109 235727 4429 INFO dfs.DataNode$DataXceiver: Receiving block blk_-5217146995455608468 src: /10.251.214.67:38871 dest: /10.251.214.67:50010
+081109 235813 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.199.225:50010 is added to blk_7481361125021302112 size 67108864
+081109 235903 4454 INFO dfs.DataNode$PacketResponder: Received block blk_-71429470616906355 of size 67108864 from /10.250.19.16
+081109 235904 4520 INFO dfs.DataNode$DataXceiver: Receiving block blk_-522892190802801712 src: /10.251.74.134:39584 dest: /10.251.74.134:50010
+081109 235919 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.107.19:50010 is added to blk_-3249711809227781266 size 67108864
+081109 235951 4525 INFO dfs.DataNode$DataXceiver: Receiving block blk_-6329494504520216748 src: /10.251.25.237:39332 dest: /10.251.25.237:50010
+081110 000117 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/sortrand/_temporary/_task_200811092030_0002_r_000318_0/part-00318. blk_-207775976836691685
+081110 000136 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.6.4:50010 is added to blk_5114010683183383297 size 67108864
+081110 000136 4627 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-7656610147924319419 terminating
+081110 000232 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/sortrand/_temporary/_task_200811092030_0002_r_000318_0/part-00318. blk_2096692261399680562
+081110 000238 4717 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-6500549130351529113 terminating
+081110 000319 4568 INFO dfs.DataNode$DataXceiver: Receiving block blk_-8255732027871411321 src: /10.251.39.179:33950 dest: /10.251.39.179:50010
+081110 000507 4619 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-2896670847306153652 terminating
+081110 000546 4624 INFO dfs.DataNode$DataXceiver: Receiving block blk_-8856628810470361280 src: /10.250.5.237:41923 dest: /10.250.5.237:50010
+081110 000616 4552 INFO dfs.DataNode$PacketResponder: Received block blk_3463540868626173125 of size 67108864 from /10.251.30.134
+081110 000657 4822 INFO dfs.DataNode$PacketResponder: Received block blk_-5309211894896608429 of size 67108864 from /10.251.202.181
+081110 000727 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.15.240:50010 is added to blk_-1055254430948037872 size 67108864
+081110 000755 4717 INFO dfs.DataNode$DataXceiver: Receiving block blk_3962600675982666210 src: /10.251.123.195:37374 dest: /10.251.123.195:50010
+081110 000820 4687 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-730776401372551814 terminating
+081110 000841 4727 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-7553009628768897700 terminating
+081110 001250 4631 INFO dfs.DataNode$PacketResponder: Received block blk_3068335169639013019 of size 67108864 from /10.251.71.68
+081110 001307 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.90.239:50010 is added to blk_-9069971851590882719 size 67108864
+081110 001337 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.67.4:50010 is added to blk_-8924134715029713489 size 67108864
+081110 001350 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.7.146:50010 is added to blk_278357163850888 size 67108864
+081110 001745 4905 INFO dfs.DataNode$DataXceiver: Receiving block blk_-5135777574223073423 src: /10.251.65.237:48648 dest: /10.251.65.237:50010
+081110 001818 4837 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-1148756466197125339 terminating
+081110 002041 4863 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_9074030793567748915 terminating
+081110 002103 4928 INFO dfs.DataNode$PacketResponder: Received block blk_-4067446915270471579 of size 25933924 from /10.251.110.8
+081110 002221 4855 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_3259872359515191972 terminating
+081110 002223 4824 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_5963816136267066159 terminating
+081110 002253 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/sortrand/_temporary/_task_200811092030_0002_r_000138_0/part-00138. blk_-210021574616486609
+081110 002337 13 INFO dfs.DataBlockScanner: Verification succeeded for blk_-1547954353065580372
+081110 002914 4955 INFO dfs.DataNode$DataXceiver: Receiving block blk_-8524274644018377752 src: /10.251.42.16:33011 dest: /10.251.42.16:50010
+081110 003441 4986 INFO dfs.DataNode$DataXceiver: Receiving block blk_-2015110815660478655 src: /10.251.35.1:53344 dest: /10.251.35.1:50010
+081110 003502 4937 INFO dfs.DataNode$PacketResponder: Received block blk_7484759945731484842 of size 67108864 from /10.251.203.149
+081110 004247 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.39.242:50010 is added to blk_-4110733372292809607 size 67108864
+081110 010354 5184 INFO dfs.DataNode$PacketResponder: Received block blk_-7152190882826520998 of size 67108864 from /10.250.14.143
+081110 010438 4917 INFO dfs.DataNode$DataXceiver: Receiving block blk_-6543889749770222531 src: /10.251.107.98:56224 dest: /10.251.107.98:50010
+081110 010506 5128 INFO dfs.DataNode$PacketResponder: Received block blk_8772892713521115147 of size 67108864 from /10.251.194.245
+081110 010525 5099 INFO dfs.DataNode$PacketResponder: Received block blk_-6979800421545566530 of size 67108864 from /10.250.10.176
+081110 010543 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt/_temporary/_task_200811092030_0003_m_000382_0/part-00382. blk_8935202950442998446
+081110 010629 5132 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-4799092443170733505 terminating
+081110 010759 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt/_temporary/_task_200811092030_0003_m_000392_0/part-00392. blk_-3010126661650043258
+081110 010801 5186 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-5215520749152394224 terminating
+081110 010815 5133 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_397848436489409658 terminating
+081110 010851 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.199.86:50010 is added to blk_-9181958042427679309 size 67108864
+081110 010917 5109 INFO dfs.DataNode$PacketResponder: Received block blk_-5124326558394984439 of size 67108864 from /10.251.122.79
+081110 010918 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.106.37:50010 is added to blk_-4741127506068309449 size 67108864
+081110 010932 5174 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-4937215748597091532 terminating
+081110 011001 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.25.237:50010 is added to blk_541463031152673662 size 67108864
+081110 011100 5230 INFO dfs.DataNode$PacketResponder: Received block blk_-7514806214244798312 of size 67108864 from /10.250.15.101
+081110 011133 5157 INFO dfs.DataNode$PacketResponder: Received block blk_-7007208336332784130 of size 67108864 from /10.251.27.63
+081110 011237 13 INFO dfs.DataBlockScanner: Verification succeeded for blk_6996194389878584395
+081110 011335 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.71.146:50010 is added to blk_-6836642008179678048 size 67108864
+081110 011352 5321 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_8060713381303305129 terminating
+081110 011406 5296 INFO dfs.DataNode$DataXceiver: Receiving block blk_5760391051658436046 src: /10.251.42.84:59752 dest: /10.251.42.84:50010
+081110 011431 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt/_temporary/_task_200811092030_0003_m_000675_0/part-00675. blk_-7866582011201618766
+081110 011448 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.214.18:50010 is added to blk_-7555801584297376435 size 67108864
+081110 011505 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.26.177:50010 is added to blk_-5949883083428548093 size 67108864
+081110 011521 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt/_temporary/_task_200811092030_0003_m_000705_0/part-00705. blk_-9162090767925303921
+081110 011538 5164 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-4196449318426994195 terminating
+081110 011713 5420 INFO dfs.DataNode$DataXceiver: Receiving block blk_4238127626194855481 src: /10.250.11.100:59324 dest: /10.250.11.100:50010
+081110 011731 5472 INFO dfs.DataNode$PacketResponder: Received block blk_-3805070405372551730 of size 67108864 from /10.251.109.236
+081110 011846 5274 INFO dfs.DataNode$PacketResponder: Received block blk_-2013946318750925538 of size 67108864 from /10.251.126.22
+081110 011925 5356 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_3278280638950561822 terminating
+081110 012005 5368 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-26568864070436835 terminating
+081110 012245 5396 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-9161369067334198861 terminating
+081110 012351 5301 INFO dfs.DataNode$PacketResponder: Received block blk_-1094025072435547068 of size 67108864 from /10.251.66.3
+081110 012357 5523 INFO dfs.DataNode$PacketResponder: Received block blk_6534693994677948144 of size 67108864 from /10.251.201.204
+081110 012426 5538 INFO dfs.DataNode$DataXceiver: Receiving block blk_7672124247291403094 src: /10.251.66.3:55531 dest: /10.251.66.3:50010
+081110 012522 5491 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-5569558931000121451 terminating
+081110 012753 5586 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-4566099704755845087 terminating
+081110 012835 5558 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-8093500164295459838 terminating
+081110 012855 5509 INFO dfs.DataNode$PacketResponder: Received block blk_-3787594914477940893 of size 67108864 from /10.251.71.16
+081110 012857 5605 INFO dfs.DataNode$PacketResponder: Received block blk_426381928692704514 of size 67108864 from /10.251.122.38
+081110 013125 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt/_temporary/_task_200811092030_0003_m_001095_0/part-01095. blk_-7413910507260978729
+081110 013220 5704 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_4774656339381154282 terminating
+081110 013231 5659 INFO dfs.DataNode$DataXceiver: Receiving block blk_-8227485321105019293 src: /10.251.195.33:56999 dest: /10.251.195.33:50010
+081110 013306 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.75.79:50010 is added to blk_5210211633167259832 size 67108864
+081110 013406 5493 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_2917692073041583988 terminating
+081110 013412 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.199.159:50010 is added to blk_-8558845834445970595 size 67108864
+081110 013502 5576 INFO dfs.DataNode$PacketResponder: Received block blk_3852281952649038166 of size 67108864 from /10.251.122.65
+081110 013506 5649 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-5442040196315589272 terminating
+081110 013537 5804 INFO dfs.DataNode$DataXceiver: Receiving block blk_-6486714614940767660 src: /10.250.11.53:48454 dest: /10.250.11.53:50010
+081110 013542 5646 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_755689327380778318 terminating
+081110 013545 5696 INFO dfs.DataNode$PacketResponder: Received block blk_-8847552694913526632 of size 67108864 from /10.251.201.204
+081110 013559 5614 INFO dfs.DataNode$PacketResponder: Received block blk_7736147489540456118 of size 67108864 from /10.251.74.227
+081110 013715 5706 INFO dfs.DataNode$PacketResponder: Received block blk_-3677956642639780952 of size 67108864 from /10.251.123.20
+081110 013721 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.73.220:50010 is added to blk_3073404534069578592 size 67108864
+081110 013855 5764 INFO dfs.DataNode$PacketResponder: Received block blk_1498192967843651378 of size 67108864 from /10.251.42.84
+081110 013938 4501 INFO dfs.DataNode$DataXceiver: Receiving block blk_148513789886825227 src: /10.251.123.33:54308 dest: /10.251.123.33:50010
+081110 014002 5798 INFO dfs.DataNode$DataXceiver: Receiving block blk_7229716389774599497 src: /10.251.201.204:38310 dest: /10.251.201.204:50010
+081110 014023 5733 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_4741107979793372752 terminating
+081110 014033 5854 INFO dfs.DataNode$DataXceiver: Receiving block blk_691517018986659607 src: /10.251.195.70:59379 dest: /10.251.195.70:50010
+081110 014043 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.203.129:50010 is added to blk_6002109944224710483 size 67108864
+081110 014050 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.122.65:50010 is added to blk_5095897972833086609 size 67108864
+081110 014138 5832 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-3802183646922512795 terminating
+081110 014145 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.201.204:50010 is added to blk_9072829105973334075 size 67108864
+081110 014207 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt/_temporary/_task_200811092030_0003_m_001365_0/part-01365. blk_4841101867353115844
+081110 014257 5803 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_1997668456720275587 terminating
+081110 014314 5599 INFO dfs.DataNode$PacketResponder: Received block blk_3304535870056962597 of size 67108864 from /10.251.203.166
+081110 014349 5817 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-4853183643928986291 terminating
+081110 014421 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.107.196:50010 is added to blk_6828121630547887549 size 67108864
+081110 014423 5775 INFO dfs.DataNode$PacketResponder: Received block blk_3084588477220583373 of size 67108864 from /10.251.125.174
+081110 014428 5801 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-653434419514937486 terminating
+081110 014519 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt/_temporary/_task_200811092030_0003_m_001506_0/part-01506. blk_1104376461837247304
+081110 014520 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.111.130:50010 is added to blk_-5511630179413516751 size 67108864
+081110 014536 6005 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_4404895858852856851 terminating
+081110 014727 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt/_temporary/_task_200811092030_0003_m_001597_0/part-01597. blk_-591552904934794824
+081110 014738 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt/_temporary/_task_200811092030_0003_m_001377_0/part-01377. blk_-8408087700903896282
+081110 014808 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.122.38:50010 is added to blk_-5404881839098659470 size 67108864
+081110 014847 5846 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_703046261120042821 terminating
+081110 014914 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt/_temporary/_task_200811092030_0003_m_001728_0/part-01728. blk_-488298625688742454
+081110 014953 5959 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_6465095458973828118 terminating
+081110 015013 6133 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-9110604833387121363 terminating
+081110 015018 5852 INFO dfs.DataNode$DataXceiver: Receiving block blk_5977008528949258706 src: /10.251.214.32:43860 dest: /10.251.214.32:50010
+081110 015024 5938 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_3781645897486585075 terminating
+081110 015031 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.11.194:50010 is added to blk_-1635752698830216319 size 67108864
+081110 015334 5970 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_3070718541088657475 terminating
+081110 015340 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt/_temporary/_task_200811092030_0003_m_001661_0/part-01661. blk_-1674094254141559552
+081110 015423 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.197.161:50010 is added to blk_6080034782037237879 size 67108864
+081110 015432 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt/_temporary/_task_200811092030_0003_m_001630_0/part-01630. blk_-8645365827804358878
+081110 015600 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt/_temporary/_task_200811092030_0003_m_001817_0/part-01817. blk_3291173852929756766
+081110 015607 6086 INFO dfs.DataNode$PacketResponder: Received block blk_892900079071425422 of size 67108864 from /10.251.73.188
+081110 015626 5971 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_2243777557693112935 terminating
+081110 015649 6096 INFO dfs.DataNode$PacketResponder: Received block blk_-8192956077351896648 of size 67108864 from /10.251.110.196
+081110 015716 6066 INFO dfs.DataNode$PacketResponder: Received block blk_5250287988089075029 of size 67108864 from /10.251.66.63
+081110 015719 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.30.6:50010 is added to blk_446513188203036714 size 67108864
+081110 015740 6116 INFO dfs.DataNode$PacketResponder: Received block blk_-2020273862360001901 of size 67108864 from /10.250.7.244
+081110 015750 5956 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_3338047823148530794 terminating
+081110 015759 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt/_temporary/_task_200811092030_0003_m_001840_0/part-01840. blk_4210124392039605712
+081110 015832 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.71.240:50010 is added to blk_-6330812010936261924 size 67108864
+081110 015942 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt/_temporary/_task_200811092030_0003_m_001976_0/part-01976. blk_-8380267327243110056
+081110 015959 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.110.160:50010 is added to blk_-8077373411465716253 size 67108864
+081110 020011 6037 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-9198375937828232046 terminating
+081110 020019 5935 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_9107849594802857322 terminating
+081110 020034 6204 INFO dfs.DataNode$DataXceiver: Receiving block blk_271142976916798281 src: /10.251.70.112:50176 dest: /10.251.70.112:50010
+081110 020140 6146 INFO dfs.DataNode$PacketResponder: Received block blk_4029732570544915384 of size 67108864 from /10.251.35.1
+081110 020249 6148 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_679168189072909208 terminating
+081110 020302 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.43.192:50010 is added to blk_6285161494041403917 size 67108864
+081110 020313 6034 INFO dfs.DataNode$PacketResponder: Received block blk_-5306443381473737599 of size 67108864 from /10.251.195.52
+081110 020322 6131 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-2466006073687914843 terminating
+081110 020325 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.43.210:50010 is added to blk_-6995454028444097802 size 67108864
+081110 020357 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.6.4:50010 is added to blk_344934934043642744 size 67108864
+081110 020458 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.7.230:50010 is added to blk_4984720043834039361 size 67108864
+081110 020509 6043 INFO dfs.DataNode$DataXceiver: Receiving block blk_6398122733993275620 src: /10.251.111.80:53737 dest: /10.251.111.80:50010
+081110 020632 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.43.192:50010 is added to blk_325981833999429148 size 67108864
+081110 020724 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_2568309208894455676 is added to invalidSet of 10.251.31.160:50010
+081110 022226 6281 INFO dfs.DataNode$DataXceiver: 10.250.19.16:50010 Served block blk_1078000656626961731 to /10.250.19.16
+081110 023456 6415 WARN dfs.DataNode$DataXceiver: 10.251.67.225:50010:Got exception while serving blk_-6900989714336081087 to /10.251.25.237:
+081110 024834 6371 INFO dfs.DataNode$DataXceiver: 10.251.126.227:50010 Served block blk_-8306714721294235181 to /10.251.126.227
+081110 030331 6561 WARN dfs.DataNode$DataXceiver: 10.251.42.191:50010:Got exception while serving blk_-8023826090828946372 to /10.251.214.130:
+081110 030942 6646 WARN dfs.DataNode$DataXceiver: 10.251.31.5:50010:Got exception while serving blk_-1367876730256254709 to /10.251.67.225:
+081110 031019 6604 INFO dfs.DataNode$DataXceiver: 10.251.126.83:50010 Served block blk_-3860894070657427592 to /10.251.126.83
+081110 032126 6555 WARN dfs.DataNode$DataXceiver: 10.251.26.8:50010:Got exception while serving blk_-7983508786213002472 to /10.251.38.197:
+081110 035357 6606 INFO dfs.DataNode$DataXceiver: 10.251.71.97:50010 Served block blk_5454332143498402824 to /10.250.15.67
+081110 040800 6739 INFO dfs.DataNode$DataXceiver: 10.250.6.214:50010 Served block blk_-3384560576963801177 to /10.250.6.214
+081110 042826 6827 INFO dfs.DataNode$DataXceiver: 10.251.67.4:50010 Served block blk_-2901225370888235702 to /10.251.91.84
+081110 045413 6957 INFO dfs.DataNode$DataXceiver: 10.251.215.50:50010 Served block blk_3963698556744744747 to /10.251.107.196
+081110 050300 6683 INFO dfs.DataNode$DataXceiver: 10.251.30.134:50010 Served block blk_2039230511363331616 to /10.251.65.203
+081110 051323 6956 INFO dfs.DataNode$DataXceiver: 10.251.71.146:50010 Served block blk_8482111101480751895 to /10.251.71.146
+081110 054642 7145 INFO dfs.DataNode$DataXceiver: 10.251.215.16:50010 Served block blk_-5919767990596301121 to /10.251.215.16
+081110 060453 7193 INFO dfs.DataNode$DataXceiver: 10.251.199.225:50010 Served block blk_8457344665564381337 to /10.251.199.225
+081110 060934 7211 INFO dfs.DataNode$DataXceiver: 10.251.66.102:50010 Served block blk_2986720270598512615 to /10.251.66.102
+081110 065635 7324 INFO dfs.DataNode$DataXceiver: 10.251.90.64:50010 Served block blk_-5719934513583495857 to /10.251.199.245
+081110 070326 7430 WARN dfs.DataNode$DataXceiver: 10.251.75.228:50010:Got exception while serving blk_-7680599654910200999 to /10.251.75.228:
+081110 070334 7327 INFO dfs.DataNode$DataXceiver: 10.251.111.37:50010 Served block blk_-6050976999174805557 to /10.251.111.37
+081110 070347 7574 INFO dfs.DataNode$DataXceiver: 10.250.10.6:50010 Served block blk_1598414622053793245 to /10.251.90.239
+081110 070614 7513 INFO dfs.DataNode$DataXceiver: 10.250.19.16:50010 Served block blk_-7837339190764609698 to /10.251.197.161
+081110 070921 7744 INFO dfs.DataNode$DataXceiver: 10.251.39.144:50010 Served block blk_-8187008844253719581 to /10.251.91.32
+081110 071154 7627 INFO dfs.DataNode$DataXceiver: 10.251.214.112:50010 Served block blk_4081177399275502985 to /10.251.110.68
+081110 071426 7742 INFO dfs.DataNode$DataXceiver: 10.251.42.191:50010 Served block blk_3515154079719300106 to /10.251.42.191
+081110 071657 7700 WARN dfs.DataNode$DataXceiver: 10.251.38.214:50010:Got exception while serving blk_5547569777499890340 to /10.251.195.52:
+081110 072121 7820 INFO dfs.DataNode$DataXceiver: 10.251.123.99:50010 Served block blk_5385121219895615240 to /10.251.71.146
+081110 072124 7772 WARN dfs.DataNode$DataXceiver: 10.251.42.246:50010:Got exception while serving blk_-7658293778087733436 to /10.251.30.179:
+081110 080546 7970 WARN dfs.DataNode$DataXceiver: 10.251.111.130:50010:Got exception while serving blk_3169060243663461885 to /10.251.214.32:
+081110 080555 8227 INFO dfs.DataNode$DataXceiver: 10.250.11.194:50010 Served block blk_3087787567144441647 to /10.251.91.84
+081110 080718 7850 INFO dfs.DataNode$DataXceiver: 10.250.10.100:50010 Served block blk_-3657665801189425193 to /10.250.10.100
+081110 080724 8080 INFO dfs.DataNode$DataXceiver: 10.251.74.79:50010 Served block blk_-3457731723401426942 to /10.251.74.79
+081110 080814 8123 INFO dfs.DataNode$DataXceiver: 10.251.42.84:50010 Served block blk_6105506155797750768 to /10.251.42.84
+081110 080847 8088 WARN dfs.DataNode$DataXceiver: 10.251.26.8:50010:Got exception while serving blk_-8522942048313632858 to /10.251.31.85:
+081110 080922 7633 INFO dfs.DataNode$DataXceiver: 10.251.203.246:50010 Served block blk_365496398062338141 to /10.251.203.246
+081110 080949 7994 INFO dfs.DataNode$DataXceiver: 10.250.19.227:50010 Served block blk_3979872751691718643 to /10.250.19.227
+081110 081044 8125 WARN dfs.DataNode$DataXceiver: 10.251.123.1:50010:Got exception while serving blk_-272707591443354058 to /10.251.198.33:
+081110 081054 8108 WARN dfs.DataNode$DataXceiver: 10.251.90.239:50010:Got exception while serving blk_-8679916835272129336 to /10.250.15.198:
+081110 081337 8145 WARN dfs.DataNode$DataXceiver: 10.251.66.102:50010:Got exception while serving blk_6106884317961925960 to /10.251.66.102:
+081110 081515 8312 WARN dfs.DataNode$DataXceiver: 10.251.31.5:50010:Got exception while serving blk_6332892729727950039 to /10.251.123.1:
+081110 081643 8095 INFO dfs.DataNode$DataXceiver: 10.251.195.52:50010 Served block blk_6655622109568310643 to /10.251.195.52
+081110 081643 8247 WARN dfs.DataNode$DataXceiver: 10.250.17.225:50010:Got exception while serving blk_-5935642747315643391 to /10.251.199.150:
+081110 081741 8169 WARN dfs.DataNode$DataXceiver: 10.251.215.70:50010:Got exception while serving blk_-20269367189114433 to /10.251.30.179:
+081110 082013 8326 INFO dfs.DataNode$DataXceiver: 10.251.43.115:50010 Served block blk_-7364557883931785608 to /10.251.43.115
+081110 082043 8305 INFO dfs.DataNode$DataXceiver: 10.251.215.16:50010 Served block blk_2322432806134104317 to /10.251.215.16
+081110 082444 8172 INFO dfs.DataNode$DataXceiver: 10.251.109.209:50010 Served block blk_4848669047361069041 to /10.251.26.177
+081110 082702 8223 WARN dfs.DataNode$DataXceiver: 10.250.15.198:50010:Got exception while serving blk_-1851265222873801714 to /10.251.195.52:
+081110 082706 8552 WARN dfs.DataNode$DataXceiver: 10.251.198.33:50010:Got exception while serving blk_-8495670552887053546 to /10.250.10.223:
+081110 082737 8341 WARN dfs.DataNode$DataXceiver: 10.250.19.227:50010:Got exception while serving blk_-7372087176866857012 to /10.251.110.68:
+081110 082954 8543 WARN dfs.DataNode$DataXceiver: 10.251.70.112:50010:Got exception while serving blk_4357276972386184626 to /10.251.74.79:
+081110 083045 8495 WARN dfs.DataNode$DataXceiver: 10.251.215.16:50010:Got exception while serving blk_-4590972095204776122 to /10.251.30.6:
+081110 083121 8197 INFO dfs.DataNode$DataXceiver: 10.251.106.214:50010 Served block blk_-8277873627721528374 to /10.251.122.79
+081110 083231 8530 INFO dfs.DataNode$DataXceiver: 10.250.10.176:50010 Served block blk_3797494971676497497 to /10.251.29.239
+081110 083328 8416 INFO dfs.DataNode$DataXceiver: 10.251.126.22:50010 Served block blk_805587860540600864 to /10.251.126.22
+081110 083453 13 INFO dfs.DataBlockScanner: Verification succeeded for blk_3141363517520802396
+081110 085042 13 INFO dfs.DataBlockScanner: Verification succeeded for blk_-1383276859207001328
+081110 085933 13 INFO dfs.DataBlockScanner: Verification succeeded for blk_-4117999745005013424
+081110 091216 7593 WARN dfs.DataNode$DataXceiver: 10.251.107.50:50010:Got exception while serving blk_4524198807982839635 to /10.251.122.79:
+081110 091550 8683 WARN dfs.DataNode$DataXceiver: 10.251.111.209:50010:Got exception while serving blk_7505828172725463922 to /10.251.111.209:
+081110 091657 8720 WARN dfs.DataNode$DataXceiver: 10.251.70.211:50010:Got exception while serving blk_424255210146453297 to /10.251.203.179:
+081110 091800 8380 INFO dfs.DataNode$DataXceiver: 10.250.14.224:50010 Served block blk_666713934549639791 to /10.250.14.224
+081110 092131 8815 INFO dfs.DataNode$DataXceiver: 10.251.30.179:50010 Served block blk_-2975629975082443857 to /10.251.30.179
+081110 092151 8601 WARN dfs.DataNode$DataXceiver: 10.251.126.22:50010:Got exception while serving blk_1686195200514944346 to /10.250.6.223:
+081110 092459 8650 INFO dfs.DataNode$DataXceiver: 10.250.9.207:50010 Served block blk_4355450627202483068 to /10.250.9.207
+081110 092815 8872 INFO dfs.DataNode$DataXceiver: 10.250.6.191:50010 Served block blk_5952254363678329024 to /10.250.6.191
+081110 093020 8827 WARN dfs.DataNode$DataXceiver: 10.251.70.211:50010:Got exception while serving blk_-667933171485085225 to /10.251.203.246:
+081110 093643 13 INFO dfs.DataBlockScanner: Verification succeeded for blk_9188832735514090334
+081110 093831 8571 INFO dfs.DataNode$DataXceiver: 10.251.106.10:50010 Served block blk_2273334621242106674 to /10.251.106.10
+081110 094019 8808 WARN dfs.DataNode$DataXceiver: 10.251.125.193:50010:Got exception while serving blk_3790492230047189408 to /10.251.199.159:
+081110 094657 7835 INFO dfs.DataNode$DataXceiver: 10.251.107.50:50010 Served block blk_-2285729896739318683 to /10.251.70.5
+081110 103026 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-1233005817943453613 is added to invalidSet of 10.251.75.49:50010
+081110 103026 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-8736461628840265232 is added to invalidSet of 10.251.195.70:50010
+081110 103027 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_166171721314010075 is added to invalidSet of 10.251.30.85:50010
+081110 103027 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-3362838757940877177 is added to invalidSet of 10.250.5.161:50010
+081110 103027 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-8026264173633579073 is added to invalidSet of 10.251.214.18:50010
+081110 103027 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_8350646254685996250 is added to invalidSet of 10.251.199.159:50010
+081110 103028 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-4702684774678057084 is added to invalidSet of 10.250.13.240:50010
+081110 103029 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_434034567989619521 is added to invalidSet of 10.251.91.15:50010
+081110 103030 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_413552235254424009 is added to invalidSet of 10.251.35.1:50010
+081110 103030 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_7177118590277025973 is added to invalidSet of 10.251.121.224:50010
+081110 103032 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_2576408434603492552 is added to invalidSet of 10.251.106.37:50010
+081110 103034 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_356592557993755459 is added to invalidSet of 10.251.109.236:50010
+081110 103035 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_9111860234027679206 is added to invalidSet of 10.251.39.209:50010
+081110 103036 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_5178539130945718870 is added to invalidSet of 10.251.107.19:50010
+081110 103037 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-1331750856499198500 is added to invalidSet of 10.251.38.53:50010
+081110 103038 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-3792836284792472725 is added to invalidSet of 10.251.106.50:50010
+081110 103038 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_6031076349976322578 is added to invalidSet of 10.251.67.225:50010
+081110 103040 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_4438674026376140804 is added to invalidSet of 10.251.106.50:50010
+081110 103041 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_1777689952069868672 is added to invalidSet of 10.251.31.85:50010
+081110 103044 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-3275788837420923000 is added to invalidSet of 10.251.109.236:50010
+081110 103045 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-6056336045486998577 is added to invalidSet of 10.251.126.255:50010
+081110 103046 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-5368528328022648701 is added to invalidSet of 10.251.202.181:50010
+081110 103047 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-9056276727170871967 is added to invalidSet of 10.251.66.3:50010
+081110 103049 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-6289001686128460561 is added to invalidSet of 10.251.91.84:50010
+081110 103049 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_6855535886504612774 is added to invalidSet of 10.251.70.211:50010
+081110 103050 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-6477590833521072407 is added to invalidSet of 10.251.39.179:50010
+081110 103050 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_865453227320668516 is added to invalidSet of 10.251.71.240:50010
+081110 103054 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_2149728827322918746 is added to invalidSet of 10.250.11.194:50010
+081110 103055 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_6324712740029479576 is added to invalidSet of 10.251.30.6:50010
+081110 103056 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_6763863888784019261 is added to invalidSet of 10.251.70.37:50010
+081110 103057 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_1543605971733759530 is added to invalidSet of 10.251.195.33:50010
+081110 103059 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-6114220623980201749 is added to invalidSet of 10.250.13.240:50010
+081110 103059 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-945770324989341170 is added to invalidSet of 10.251.31.180:50010
+081110 103107 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-5145886774827574591 is added to invalidSet of 10.251.105.189:50010
+081110 103109 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_3598904881888399067 is added to invalidSet of 10.250.5.237:50010
+081110 103111 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-6255015379143356507 is added to invalidSet of 10.251.111.37:50010
+081110 103111 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_8247499802516177421 is added to invalidSet of 10.250.7.96:50010
+081110 103111 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-8403618945096094999 is added to invalidSet of 10.251.42.9:50010
+081110 103112 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-2012430628930443984 is added to invalidSet of 10.250.11.100:50010
+081110 103112 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_7819984111120374407 is added to invalidSet of 10.251.30.6:50010
+081110 103113 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_4499140370762613763 is added to invalidSet of 10.251.43.115:50010
+081110 103114 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_2304296078821316612 is added to invalidSet of 10.251.39.64:50010
+081110 103114 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_358331073189608564 is added to invalidSet of 10.251.67.225:50010
+081110 103114 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_8404604116961181201 is added to invalidSet of 10.250.13.188:50010
+081110 103117 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-3582070652284403613 is added to invalidSet of 10.250.10.213:50010
+081110 103123 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-4954795063440871977 is added to invalidSet of 10.251.203.80:50010
+081110 103127 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-6640779266188771131 is added to invalidSet of 10.251.126.83:50010
+081110 103130 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_3858015337960682724 is added to invalidSet of 10.251.214.130:50010
+081110 103130 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_570916157110129687 is added to invalidSet of 10.251.214.18:50010
+081110 103132 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-7418499425236853516 is added to invalidSet of 10.251.203.4:50010
+081110 103136 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-7894824934989391122 is added to invalidSet of 10.251.38.197:50010
+081110 103137 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-5005618994659797504 is added to invalidSet of 10.251.125.193:50010
+081110 103137 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_7932704730736035192 is added to invalidSet of 10.251.199.245:50010
+081110 103139 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-2834195813213005328 is added to invalidSet of 10.250.7.244:50010
+081110 103141 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-5972745462629982078 is added to invalidSet of 10.251.31.5:50010
+081110 103142 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-7111788899695387329 is added to invalidSet of 10.251.75.228:50010
+081110 103146 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-1110880362999960078 is added to invalidSet of 10.251.194.147:50010
+081110 103146 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_6489659315944341351 is added to invalidSet of 10.251.106.50:50010
+081110 103146 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_7324196727355442810 is added to invalidSet of 10.251.203.80:50010
+081110 103147 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-2589662411410634043 is added to invalidSet of 10.251.42.16:50010
+081110 103147 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_8602496359012842630 is added to invalidSet of 10.250.7.32:50010
+081110 103148 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-133919539232421451 is added to invalidSet of 10.250.10.176:50010
+081110 103149 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-6136511938931864993 is added to invalidSet of 10.250.14.38:50010
+081110 103149 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_8871064397020855320 is added to invalidSet of 10.251.42.84:50010
+081110 103201 19 INFO dfs.FSDataset: Deleting block blk_8483848473254499625 file /mnt/hadoop/dfs/data/current/subdir51/blk_8483848473254499625
+081110 103233 8946 INFO dfs.DataNode$PacketResponder: Received block blk_-9188933731705791676 of size 67108864 from /10.251.39.192
+081110 103257 19 INFO dfs.FSDataset: Deleting block blk_-8898274302731129139 file /mnt/hadoop/dfs/data/current/subdir18/blk_-8898274302731129139
+081110 103320 18 INFO dfs.FSDataset: Deleting block blk_-8014701913801168461 file /mnt/hadoop/dfs/data/current/subdir27/blk_-8014701913801168461
+081110 103321 19 INFO dfs.FSDataset: Deleting block blk_-8775602795571523802 file /mnt/hadoop/dfs/data/current/subdir29/blk_-8775602795571523802
+081110 103327 19 INFO dfs.FSDataset: Deleting block blk_-7928230000822317050 file /mnt/hadoop/dfs/data/current/subdir9/blk_-7928230000822317050
+081110 103328 19 INFO dfs.FSDataset: Deleting block blk_8303413189200230139 file /mnt/hadoop/dfs/data/current/subdir32/blk_8303413189200230139
+081110 103331 19 INFO dfs.FSDataset: Deleting block blk_-9038475355621289969 file /mnt/hadoop/dfs/data/current/subdir41/blk_-9038475355621289969
+081110 103333 9016 INFO dfs.DataNode$PacketResponder: Received block blk_4263664068073345850 of size 67108864 from /10.251.214.67
+081110 103335 19 INFO dfs.FSDataset: Deleting block blk_-8848810702648406400 file /mnt/hadoop/dfs/data/current/subdir11/blk_-8848810702648406400
+081110 103340 9214 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-6997219177553478996 terminating
+081110 103343 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand/_temporary/_task_200811101024_0001_m_000206_0/part-00206. blk_-2230892279625104430
+081110 103347 19 INFO dfs.FSDataset: Deleting block blk_-7515058933811567980 file /mnt/hadoop/dfs/data/current/subdir1/blk_-7515058933811567980
+081110 103348 19 INFO dfs.FSDataset: Deleting block blk_-8484827087450439270 file /mnt/hadoop/dfs/data/current/subdir25/blk_-8484827087450439270
+081110 103349 19 INFO dfs.FSDataset: Deleting block blk_-8144387882075572886 file /mnt/hadoop/dfs/data/current/subdir42/blk_-8144387882075572886
+081110 103354 19 INFO dfs.FSDataset: Deleting block blk_-8383503596684323017 file /mnt/hadoop/dfs/data/current/subdir26/blk_-8383503596684323017
+081110 103400 19 INFO dfs.FSDataset: Deleting block blk_-8796256534683400159 file /mnt/hadoop/dfs/data/current/subdir18/blk_-8796256534683400159
+081110 103403 19 INFO dfs.FSDataset: Deleting block blk_-8775602795571523802 file /mnt/hadoop/dfs/data/current/subdir41/blk_-8775602795571523802
+081110 103412 7249 INFO dfs.DataNode$PacketResponder: Received block blk_4098532420907418423 of size 67108864 from /10.251.43.147
+081110 103430 19 INFO dfs.FSDataset: Deleting block blk_-4368236874477798428 file /mnt/hadoop/dfs/data/current/subdir33/blk_-4368236874477798428
+081110 103432 19 INFO dfs.FSDataset: Deleting block blk_-4223625526513535681 file /mnt/hadoop/dfs/data/current/subdir60/blk_-4223625526513535681
+081110 103437 19 INFO dfs.FSDataset: Deleting block blk_-6400421658804613208 file /mnt/hadoop/dfs/data/current/subdir29/blk_-6400421658804613208
+081110 103442 19 INFO dfs.FSDataset: Deleting block blk_-5880591395067598620 file /mnt/hadoop/dfs/data/current/subdir32/blk_-5880591395067598620
+081110 103442 19 INFO dfs.FSDataset: Deleting block blk_-7096508472270520039 file /mnt/hadoop/dfs/data/current/subdir20/blk_-7096508472270520039
+081110 103444 19 INFO dfs.FSDataset: Deleting block blk_-1939956833921604216 file /mnt/hadoop/dfs/data/current/subdir34/blk_-1939956833921604216
+081110 103512 19 INFO dfs.FSDataset: Deleting block blk_-3860035787700398391 file /mnt/hadoop/dfs/data/current/subdir6/blk_-3860035787700398391
+081110 103524 19 INFO dfs.FSDataset: Deleting block blk_-6008397446568765070 file /mnt/hadoop/dfs/data/current/blk_-6008397446568765070
+081110 103527 19 INFO dfs.FSDataset: Deleting block blk_-2425070029518924403 file /mnt/hadoop/dfs/data/current/subdir39/blk_-2425070029518924403
+081110 103533 18 INFO dfs.FSDataset: Deleting block blk_826351419727053015 file /mnt/hadoop/dfs/data/current/subdir6/blk_826351419727053015
+081110 103533 19 INFO dfs.FSDataset: Deleting block blk_-3437475890798229344 file /mnt/hadoop/dfs/data/current/subdir57/blk_-3437475890798229344
+081110 103534 19 INFO dfs.FSDataset: Deleting block blk_-1492402439215451727 file /mnt/hadoop/dfs/data/current/subdir25/blk_-1492402439215451727
+081110 103538 18 INFO dfs.FSDataset: Deleting block blk_-4298255715894292387 file /mnt/hadoop/dfs/data/current/subdir38/blk_-4298255715894292387
+081110 103547 19 INFO dfs.FSDataset: Deleting block blk_-4295805058711840933 file /mnt/hadoop/dfs/data/current/subdir0/blk_-4295805058711840933
+081110 103548 19 INFO dfs.FSDataset: Deleting block blk_830855781964014378 file /mnt/hadoop/dfs/data/current/subdir48/blk_830855781964014378
+081110 103551 19 INFO dfs.FSDataset: Deleting block blk_8291708741145026623 file /mnt/hadoop/dfs/data/current/subdir57/blk_8291708741145026623
+081110 103552 19 INFO dfs.FSDataset: Deleting block blk_-921231092429668424 file /mnt/hadoop/dfs/data/current/subdir23/blk_-921231092429668424
+081110 103553 19 INFO dfs.FSDataset: Deleting block blk_-1581605246928123722 file /mnt/hadoop/dfs/data/current/subdir13/blk_-1581605246928123722
+081110 103554 18 INFO dfs.FSDataset: Deleting block blk_-2445347158368483245 file /mnt/hadoop/dfs/data/current/subdir30/blk_-2445347158368483245
+081110 103554 19 INFO dfs.FSDataset: Deleting block blk_-1897524391075610396 file /mnt/hadoop/dfs/data/current/subdir47/blk_-1897524391075610396
+081110 103557 19 INFO dfs.FSDataset: Deleting block blk_-8588908000680498 file /mnt/hadoop/dfs/data/current/subdir21/blk_-8588908000680498
+081110 103558 19 INFO dfs.FSDataset: Deleting block blk_561417755647618727 file /mnt/hadoop/dfs/data/current/subdir4/blk_561417755647618727
+081110 103600 19 INFO dfs.FSDataset: Deleting block blk_-6127741703501838658 file /mnt/hadoop/dfs/data/current/subdir53/blk_-6127741703501838658
+081110 103603 18 INFO dfs.FSDataset: Deleting block blk_-3636681193077858741 file /mnt/hadoop/dfs/data/current/subdir37/blk_-3636681193077858741
+081110 103615 18 INFO dfs.FSDataset: Deleting block blk_-643763844763678010 file /mnt/hadoop/dfs/data/current/subdir29/blk_-643763844763678010
+081110 103615 19 INFO dfs.FSDataset: Deleting block blk_-2826763604408365998 file /mnt/hadoop/dfs/data/current/subdir40/blk_-2826763604408365998
+081110 103618 19 INFO dfs.FSDataset: Deleting block blk_2278708746675870163 file /mnt/hadoop/dfs/data/current/subdir27/blk_2278708746675870163
+081110 103621 19 INFO dfs.FSDataset: Deleting block blk_153508158653341141 file /mnt/hadoop/dfs/data/current/subdir50/blk_153508158653341141
+081110 103621 19 INFO dfs.FSDataset: Deleting block blk_-1775264355226395799 file /mnt/hadoop/dfs/data/current/subdir26/blk_-1775264355226395799
+081110 103626 18 INFO dfs.FSDataset: Deleting block blk_-1599621098605751235 file /mnt/hadoop/dfs/data/current/subdir16/blk_-1599621098605751235
+081110 103631 19 INFO dfs.FSDataset: Deleting block blk_-1111344660779690782 file /mnt/hadoop/dfs/data/current/subdir40/blk_-1111344660779690782
+081110 103631 19 INFO dfs.FSDataset: Deleting block blk_3585588704565901062 file /mnt/hadoop/dfs/data/current/subdir15/blk_3585588704565901062
+081110 103634 19 INFO dfs.FSDataset: Deleting block blk_2756799797410851893 file /mnt/hadoop/dfs/data/current/subdir24/blk_2756799797410851893
+081110 103641 19 INFO dfs.FSDataset: Deleting block blk_7323287581932922676 file /mnt/hadoop/dfs/data/current/subdir12/blk_7323287581932922676
+081110 103655 9020 INFO dfs.DataNode$PacketResponder: Received block blk_-4935573595350235765 of size 67108864 from /10.251.123.195
+081110 103657 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand/_temporary/_task_200811101024_0001_m_000097_0/part-00097. blk_496376132244907301
+081110 103659 19 INFO dfs.FSDataset: Deleting block blk_2731617036199392057 file /mnt/hadoop/dfs/data/current/subdir39/blk_2731617036199392057
+081110 103704 19 INFO dfs.FSDataset: Deleting block blk_7190156588310412626 file /mnt/hadoop/dfs/data/current/subdir30/blk_7190156588310412626
+081110 103717 19 INFO dfs.FSDataset: Deleting block blk_8189008752707332487 file /mnt/hadoop/dfs/data/current/subdir7/blk_8189008752707332487
+081110 103719 19 INFO dfs.FSDataset: Deleting block blk_6828263829429857572 file /mnt/hadoop/dfs/data/current/subdir26/blk_6828263829429857572
+081110 103729 19 INFO dfs.FSDataset: Deleting block blk_8492196963764530259 file /mnt/hadoop/dfs/data/current/subdir45/blk_8492196963764530259
+081110 103731 19 INFO dfs.FSDataset: Deleting block blk_7942183449206967755 file /mnt/hadoop/dfs/data/current/subdir30/blk_7942183449206967755
+081110 103734 19 INFO dfs.FSDataset: Deleting block blk_6223504502438507199 file /mnt/hadoop/dfs/data/current/subdir0/blk_6223504502438507199
+081110 103735 19 INFO dfs.FSDataset: Deleting block blk_7519257846502835091 file /mnt/hadoop/dfs/data/current/subdir15/blk_7519257846502835091
+081110 103739 19 INFO dfs.FSDataset: Deleting block blk_5272005015837990021 file /mnt/hadoop/dfs/data/current/subdir0/blk_5272005015837990021
+081110 103743 19 INFO dfs.FSDataset: Deleting block blk_7090935285617451450 file /mnt/hadoop/dfs/data/current/subdir60/blk_7090935285617451450
+081110 103749 19 INFO dfs.FSDataset: Deleting block blk_8145984793403459836 file /mnt/hadoop/dfs/data/current/blk_8145984793403459836
+081110 103755 19 INFO dfs.FSDataset: Deleting block blk_7603278760520020831 file /mnt/hadoop/dfs/data/current/subdir59/blk_7603278760520020831
+081110 103801 19 INFO dfs.FSDataset: Deleting block blk_9169945668827621796 file /mnt/hadoop/dfs/data/current/subdir50/blk_9169945668827621796
+081110 103812 9115 INFO dfs.DataNode$PacketResponder: Received block blk_-5668584889663038916 of size 67108864 from /10.250.9.207
+081110 103818 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.194.147:50010 is added to blk_5277338321835341602 size 67108864
+081110 103819 19 INFO dfs.FSDataset: Deleting block blk_6973321719929905054 file /mnt/hadoop/dfs/data/current/subdir14/blk_6973321719929905054
+081110 103821 19 INFO dfs.FSDataset: Deleting block blk_5948455948626091880 file /mnt/hadoop/dfs/data/current/subdir28/blk_5948455948626091880
+081110 103827 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.75.49:50010 is added to blk_-3684613761619321001 size 67108864
+081110 103840 19 INFO dfs.FSDataset: Deleting block blk_6497260538939100482 file /mnt/hadoop/dfs/data/current/subdir46/blk_6497260538939100482
+081110 103840 9117 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-6991853982611346454 terminating
+081110 103850 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand/_temporary/_task_200811101024_0001_m_000056_0/part-00056. blk_6140788650991100539
+081110 103922 19 INFO dfs.FSDataset: Deleting block blk_7754477838724397551 file /mnt/hadoop/dfs/data/current/subdir46/blk_7754477838724397551
+081110 104018 9085 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-3452734573703603740 terminating
+081110 104047 8882 INFO dfs.DataNode$PacketResponder: Received block blk_-4034227974316905164 of size 67108864 from /10.250.15.198
+081110 104224 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand/_temporary/_task_200811101024_0001_m_000346_0/part-00346. blk_-2016403519138424998
+081110 104231 8978 INFO dfs.DataNode$DataXceiver: Receiving block blk_2972699288862031202 src: /10.250.5.161:51077 dest: /10.250.5.161:50010
+081110 104309 9091 INFO dfs.DataNode$DataXceiver: Receiving block blk_-4956232013010963754 src: /10.251.126.22:58984 dest: /10.251.126.22:50010
+081110 104321 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.15.198:50010 is added to blk_8894334107354324777 size 3549832
+081110 104357 9263 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-6035642070260562886 terminating
+081110 104401 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.107.196:50010 is added to blk_4802366409699286298 size 3547304
+081110 104404 9034 INFO dfs.DataNode$DataXceiver: Receiving block blk_-1753161039594546561 src: /10.251.203.149:33685 dest: /10.251.203.149:50010
+081110 104407 9110 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_859668537217019080 terminating
+081110 104600 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand/_temporary/_task_200811101024_0001_m_000121_0/part-00121. blk_-2073265102548439691
+081110 104825 9232 INFO dfs.DataNode$PacketResponder: Received block blk_3083630442630693250 of size 67108864 from /10.251.215.70
+081110 104834 9213 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-4624597753370705281 terminating
+081110 104839 9163 INFO dfs.DataNode$PacketResponder: Received block blk_-5236578579938215340 of size 67108864 from /10.250.7.244
+081110 104847 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.39.144:50010 is added to blk_-6592952246351162022 size 67108864
+081110 104914 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.14.224:50010 is added to blk_-3329473910909732817 size 67108864
+081110 105000 19 INFO dfs.FSDataset: Deleting block blk_-1347057913082589493 file /mnt/hadoop/dfs/data/current/subdir56/blk_-1347057913082589493
+081110 105149 9274 INFO dfs.DataNode$DataXceiver: Receiving block blk_-8198423074054354279 src: /10.251.203.149:46429 dest: /10.251.203.149:50010
+081110 105203 9267 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_391813102554451063 terminating
+081110 105219 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.214.67:50010 is added to blk_-6449891932967810179 size 67108864
+081110 105252 9416 INFO dfs.DataNode$DataXceiver: Receiving block blk_-8563999607069929505 src: /10.251.107.19:60076 dest: /10.251.107.19:50010
+081110 105345 19 INFO dfs.FSDataset: Deleting block blk_-4304240611296196935 file /mnt/hadoop/dfs/data/current/subdir55/blk_-4304240611296196935
+081110 105456 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.110.68:50010 is added to blk_-3663004104512304532 size 67108864
+081110 105512 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand/_temporary/_task_200811101024_0001_m_000749_0/part-00749. blk_-6909607053783233975
+081110 105521 9428 INFO dfs.DataNode$PacketResponder: Received block blk_-2141627858612526069 of size 67108864 from /10.251.111.37
+081110 105553 9531 INFO dfs.DataNode$DataXceiver: Receiving block blk_5272731391668336674 src: /10.250.6.191:46509 dest: /10.250.6.191:50010
+081110 105607 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.39.179:50010 is added to blk_5491101910066444061 size 67108864
+081110 105628 19 INFO dfs.FSDataset: Deleting block blk_5075966182561035053 file /mnt/hadoop/dfs/data/current/subdir53/blk_5075966182561035053
+081110 105910 9510 INFO dfs.DataNode$PacketResponder: Received block blk_-5421365489363678155 of size 67108864 from /10.251.122.38
+081110 105927 9498 INFO dfs.DataNode$PacketResponder: Received block blk_2294700909811950327 of size 67108864 from /10.251.90.64
+081110 110021 9609 INFO dfs.DataNode$PacketResponder: Received block blk_7224257732880626802 of size 67108864 from /10.251.122.79
+081110 110036 9429 INFO dfs.DataNode$PacketResponder: Received block blk_-8049908920306758342 of size 67108864 from /10.251.73.220
+081110 110055 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.7.244:50010 is added to blk_-6582383997201802925 size 67108864
+081110 110059 9428 INFO dfs.DataNode$PacketResponder: Received block blk_6746178639682808096 of size 67108864 from /10.251.125.174
+081110 110101 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.38.214:50010 is added to blk_-5363213609331400263 size 67108864
+081110 110155 9579 INFO dfs.DataNode$PacketResponder: Received block blk_-5586529360624346565 of size 67108864 from /10.251.43.115
+081110 110208 9551 INFO dfs.DataNode$PacketResponder: Received block blk_2063252936853409868 of size 67108864 from /10.251.43.192
+081110 110324 8497 INFO dfs.DataNode$DataXceiver: Receiving block blk_8752665860595246441 src: /10.251.70.5:44006 dest: /10.251.70.5:50010
+081110 110353 9313 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_2974262690755997396 terminating
+081110 110627 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.194.213:50010 is added to blk_-7030770677241078854 size 67108864
+081110 110827 9664 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_3318864983801406136 terminating
+081110 110921 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand/_temporary/_task_200811101024_0001_m_001197_0/part-01197. blk_-5255262711039499896
+081110 110933 9676 INFO dfs.DataNode$DataXceiver: Receiving block blk_-3612946656596896413 src: /10.251.105.189:48488 dest: /10.251.105.189:50010
+081110 110942 9749 INFO dfs.DataNode$PacketResponder: Received block blk_8751697793900992450 of size 67108864 from /10.251.71.16
+081110 111026 9675 INFO dfs.DataNode$DataXceiver: Receiving block blk_5816171803790152026 src: /10.251.194.102:43940 dest: /10.251.194.102:50010
+081110 111043 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.66.192:50010 is added to blk_-6068587951382721748 size 67108864
+081110 111043 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand/_temporary/_task_200811101024_0001_m_001353_0/part-01353. blk_5782729236964719738
+081110 111229 9504 INFO dfs.DataNode$PacketResponder: Received block blk_-2856928563366064757 of size 67108864 from /10.251.42.9
+081110 111248 9723 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_8348114876238571434 terminating
+081110 111308 9973 INFO dfs.DataNode$DataXceiver: Receiving block blk_1744485040428751334 src: /10.250.5.237:52234 dest: /10.250.5.237:50010
+081110 111404 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand/_temporary/_task_200811101024_0001_m_001495_0/part-01495. blk_-7592643790414500555
+081110 111405 9848 INFO dfs.DataNode$PacketResponder: Received block blk_-5960135894031733009 of size 67108864 from /10.251.126.83
+081110 111409 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.14.143:50010 is added to blk_8952177028039691517 size 67108864
+081110 111415 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.13.240:50010 is added to blk_939695665085237271 size 67108864
+081110 111547 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand/_temporary/_task_200811101024_0001_m_001587_0/part-01587. blk_6374836031306809839
+081110 111638 10033 INFO dfs.DataNode$DataXceiver: Receiving block blk_1394107495884949139 src: /10.250.10.100:33314 dest: /10.250.10.100:50010
+081110 111647 9920 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-1751996688557225241 terminating
+081110 111650 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.127.47:50010 is added to blk_-3990317238913332296 size 67108864
+081110 111732 9557 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_7837529475466774167 terminating
+081110 111748 9582 INFO dfs.DataNode$DataXceiver: Receiving block blk_1057763407402503745 src: /10.251.30.134:36059 dest: /10.251.30.134:50010
+081110 111807 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.67.113:50010 is added to blk_8988793695103110546 size 67108864
+081110 111826 9879 INFO dfs.DataNode$PacketResponder: Received block blk_-5340841684362207777 of size 67108864 from /10.251.198.33
+081110 111909 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.123.99:50010 is added to blk_-2600305892036631113 size 67108864
+081110 111958 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.107.19:50010 is added to blk_-2144263949276079479 size 3547172
+081110 112055 10002 INFO dfs.DataNode$DataXceiver: Receiving block blk_-6927870228542972281 src: /10.250.7.230:41059 dest: /10.250.7.230:50010
+081110 112152 9621 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_6610244864386894422 terminating
+081110 112155 13 INFO dfs.DataBlockScanner: Verification succeeded for blk_774612454978154966
+081110 112234 9888 INFO dfs.DataNode$DataXceiver: Receiving block blk_6672666770563118759 src: /10.251.71.68:44457 dest: /10.251.71.68:50010
+081110 112310 9858 INFO dfs.DataNode$DataXceiver: Receiving block blk_4783621682384104986 src: /10.251.193.224:52556 dest: /10.251.193.224:50010
+081110 112324 9997 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-1387034299358896632 terminating
+081110 112448 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.111.228:50010 is added to blk_-5012639079435860269 size 67108864
+081110 112511 10021 INFO dfs.DataNode$PacketResponder: Received block blk_5600017220681756254 of size 67108864 from /10.251.214.130
+081110 112516 10267 INFO dfs.DataNode$DataXceiver: Receiving block blk_8235751201501175836 src: /10.250.11.194:37449 dest: /10.250.11.194:50010
+081110 112615 9713 INFO dfs.DataNode$DataXceiver: Receiving block blk_-8838161455213213548 src: /10.251.199.150:58165 dest: /10.251.199.150:50010
+081110 112629 10027 INFO dfs.DataNode$PacketResponder: Received block blk_-3741526967786688540 of size 67108864 from /10.251.74.79
+081110 112653 10042 INFO dfs.DataNode$PacketResponder: Received block blk_120277101968534224 of size 67108864 from /10.251.122.65
+081110 112716 9992 INFO dfs.DataNode$DataXceiver: Receiving block blk_7535677865140289610 src: /10.251.26.131:47660 dest: /10.251.26.131:50010
+081110 112739 10109 INFO dfs.DataNode$PacketResponder: Received block blk_-5814328448485070742 of size 67108864 from /10.251.74.134
+081110 112744 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.10.100:50010 is added to blk_1021828391502582165 size 67108864
+081110 112807 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.38.53:50010 is added to blk_3202507081359904616 size 67108864
+081110 113017 10093 INFO dfs.DataNode$DataXceiver: Receiving block blk_102441832197223997 src: /10.251.123.195:49611 dest: /10.251.123.195:50010
+081110 113407 10381 INFO dfs.DataNode$PacketResponder: Received block blk_3242229894054064344 of size 3540106 from /10.250.15.240
+081110 113636 19 INFO dfs.FSDataset: Deleting block blk_-7601381921195183756 file /mnt/hadoop/dfs/data/current/subdir48/blk_-7601381921195183756
+081110 113919 10209 INFO dfs.DataNode$PacketResponder: Received block blk_2157471834570224881 of size 67108864 from /10.251.126.22
+081110 113952 10299 INFO dfs.DataNode$PacketResponder: Received block blk_-7029628814943626474 of size 67108864 from /10.250.7.230
+081110 113955 10279 INFO dfs.DataNode$DataXceiver: Receiving block blk_-931590117143327078 src: /10.251.42.191:44480 dest: /10.251.42.191:50010
+081110 114005 10102 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_4967492069970766092 terminating
+081110 114019 10028 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-1485317050914225917 terminating
+081110 114020 10232 INFO dfs.DataNode$DataXceiver: Receiving block blk_1727371778357941761 src: /10.251.126.255:42844 dest: /10.251.126.255:50010
+081110 114119 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.26.177:50010 is added to blk_-2402036602753320612 size 67108864
+081110 114144 10436 INFO dfs.DataNode$PacketResponder: Received block blk_-1849105860762445186 of size 67108864 from /10.251.91.229
+081110 114231 10363 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7820996703068538967 src: /10.251.35.1:59569 dest: /10.251.35.1:50010
+081110 114309 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt2/_temporary/_task_200811101024_0002_m_000299_0/part-00299. blk_4984150784048864430
+081110 114315 10226 INFO dfs.DataNode$PacketResponder: Received block blk_1646909113279517647 of size 67108864 from /10.251.214.130
+081110 114319 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.25.237:50010 is added to blk_-8145226289286457574 size 67108864
+081110 114347 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.214.18:50010 is added to blk_5809900021002850724 size 67108864
+081110 114354 10356 INFO dfs.DataNode$DataXceiver: Receiving block blk_2735034460607366827 src: /10.251.91.15:57370 dest: /10.251.91.15:50010
+081110 114357 10454 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7486746679002157277 src: /10.251.42.207:57669 dest: /10.251.42.207:50010
+081110 114449 10421 INFO dfs.DataNode$DataXceiver: Receiving block blk_-8876879715755468215 src: /10.251.111.80:43834 dest: /10.251.111.80:50010
+081110 114454 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt2/_temporary/_task_200811101024_0002_m_000054_0/part-00054. blk_-4139299269696044017
+081110 114504 10561 INFO dfs.DataNode$DataXceiver: Receiving block blk_591323161994959677 src: /10.251.195.33:50123 dest: /10.251.195.33:50010
+081110 114637 10468 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-5828360070550196756 terminating
+081110 114717 10303 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-7683667795522321323 terminating
+081110 114724 10433 INFO dfs.DataNode$DataXceiver: Receiving block blk_7733243482102436613 src: /10.250.6.223:34069 dest: /10.250.6.223:50010
+081110 114738 10395 INFO dfs.DataNode$DataXceiver: Receiving block blk_2980964138205299397 src: /10.251.110.196:53450 dest: /10.251.110.196:50010
+081110 115017 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.127.191:50010 is added to blk_1589878256898761558 size 67108864
+081110 115202 10582 INFO dfs.DataNode$DataXceiver: Receiving block blk_-2746863406163228797 src: /10.251.39.160:35642 dest: /10.251.39.160:50010
+081110 115204 10569 INFO dfs.DataNode$DataXceiver: Receiving block blk_3067558337579347170 src: /10.250.6.191:34137 dest: /10.250.6.191:50010
+081110 115226 10579 INFO dfs.DataNode$DataXceiver: Receiving block blk_8992894896370738220 src: /10.251.43.210:54766 dest: /10.251.43.210:50010
+081110 115408 10446 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7230947007726948080 src: /10.251.29.239:53564 dest: /10.251.29.239:50010
+081110 115526 10492 INFO dfs.DataNode$DataXceiver: Receiving block blk_1869228153483717375 src: /10.251.203.4:56599 dest: /10.251.203.4:50010
+081110 115614 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.65.203:50010 is added to blk_-3949633496933134307 size 67108864
+081110 115700 10671 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-8745453424063341007 terminating
+081110 115734 10668 INFO dfs.DataNode$PacketResponder: Received block blk_-2117066166574895060 of size 67108864 from /10.251.73.188
+081110 115737 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.195.33:50010 is added to blk_512039711533506696 size 67108864
+081110 115742 10672 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_6017354285686373326 terminating
+081110 115804 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.126.83:50010 is added to blk_5176855630425795751 size 67108864
+081110 115934 10597 INFO dfs.DataNode$PacketResponder: Received block blk_-4433556521525567493 of size 28492032 from /10.250.6.4
+081110 120103 10778 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-5321676321043683563 terminating
+081110 120139 10638 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-357695136519539363 terminating
+081110 120233 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.111.37:50010 is added to blk_-7603740654202748654 size 67108864
+081110 120246 10414 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_1279439901767890758 terminating
+081110 120247 10427 INFO dfs.DataNode$DataXceiver: Receiving block blk_8942969309743886844 src: /10.251.110.68:58266 dest: /10.251.110.68:50010
+081110 120247 10525 INFO dfs.DataNode$PacketResponder: Received block blk_469871968689793326 of size 67108864 from /10.251.30.179
+081110 120410 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt2/_temporary/_task_200811101024_0002_m_001080_0/part-01080. blk_2847401988110989655
+081110 120429 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.197.226:50010 is added to blk_4307207852226914003 size 67108864
+081110 120516 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.73.220:50010 is added to blk_3506875694435075421 size 67108864
+081110 120524 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.202.134:50010 is added to blk_-4945182943709543868 size 67108864
+081110 120621 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt2/_temporary/_task_200811101024_0002_m_000809_0/part-00809. blk_7550266985912909372
+081110 120718 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.215.192:50010 is added to blk_-4619809198345103330 size 67108864
+081110 120807 10546 INFO dfs.DataNode$PacketResponder: Received block blk_4614530673206341566 of size 67108864 from /10.251.91.229
+081110 120857 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.201.204:50010 is added to blk_6125469222540396851 size 67108864
+081110 120931 10872 INFO dfs.DataNode$DataXceiver: Receiving block blk_6868050965297613251 src: /10.251.201.204:47734 dest: /10.251.201.204:50010
+081110 121045 10833 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7266711648018793699 src: /10.251.31.242:47086 dest: /10.251.31.242:50010
+081110 121136 10865 INFO dfs.DataNode$DataXceiver: Receiving block blk_9146254623576405494 src: /10.250.7.146:60294 dest: /10.250.7.146:50010
+081110 121153 10880 INFO dfs.DataNode$PacketResponder: Received block blk_-6966935672736779591 of size 67108864 from /10.251.90.64
+081110 121156 11034 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7411687001739959508 src: /10.251.122.65:46080 dest: /10.251.122.65:50010
+081110 121202 11005 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_6514181997629420906 terminating
+081110 121248 10737 INFO dfs.DataNode$DataXceiver: Receiving block blk_-4434479572312007079 src: /10.251.30.101:60539 dest: /10.251.30.101:50010
+081110 121402 10935 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-3339018122410311668 terminating
+081110 121647 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.91.32:50010 is added to blk_5272761429354463572 size 67108864
+081110 121711 11025 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-1680563440028826904 terminating
+081110 121758 10889 INFO dfs.DataNode$PacketResponder: Received block blk_-5671206752084326639 of size 67108864 from /10.251.214.67
+081110 121758 13 INFO dfs.DataBlockScanner: Verification succeeded for blk_1649162819905816843
+081110 121943 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt2/_temporary/_task_200811101024_0002_m_001335_0/part-01335. blk_-2541428592126088938
+081110 121951 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.66.3:50010 is added to blk_6547729596040509998 size 67108864
+081110 122121 10760 INFO dfs.DataNode$DataXceiver: Receiving block blk_-3673133694834392576 src: /10.251.109.209:49088 dest: /10.251.109.209:50010
+081110 122207 11264 INFO dfs.DataNode$PacketResponder: Received block blk_48742413802609430 of size 67108864 from /10.251.106.10
+081110 122210 11081 INFO dfs.DataNode$DataXceiver: Receiving block blk_6085274723649229095 src: /10.251.127.191:51113 dest: /10.251.127.191:50010
+081110 122309 11240 INFO dfs.DataNode$PacketResponder: Received block blk_-227411387418683230 of size 67108864 from /10.251.194.213
+081110 122314 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.31.160:50010 is added to blk_3079488924320077240 size 67108864
+081110 122407 11042 INFO dfs.DataNode$PacketResponder: Received block blk_692184983396207285 of size 67108864 from /10.250.6.214
+081110 122444 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.66.102:50010 is added to blk_-5009274684359267777 size 67108864
+081110 122607 11193 INFO dfs.DataNode$PacketResponder: Received block blk_2599050023684318911 of size 67108864 from /10.251.106.10
+081110 122609 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.123.195:50010 is added to blk_3911263675181899748 size 67108864
+081110 122630 10903 INFO dfs.DataNode$DataXceiver: Receiving block blk_5641239200978828454 src: /10.251.42.9:51808 dest: /10.251.42.9:50010
+081110 122648 11281 INFO dfs.DataNode$DataXceiver: Receiving block blk_-8852638972311349374 src: /10.251.107.227:46913 dest: /10.251.107.227:50010
+081110 122702 11168 INFO dfs.DataNode$DataXceiver: Receiving block blk_-719498947487451844 src: /10.251.125.193:52079 dest: /10.251.125.193:50010
+081110 122717 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.66.63:50010 is added to blk_-3170270010972115378 size 67108864
+081110 122719 11316 INFO dfs.DataNode$DataXceiver: Receiving block blk_6988110707613820142 src: /10.251.123.132:47658 dest: /10.251.123.132:50010
+081110 123008 11210 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-1490623381339215624 terminating
+081110 123012 10997 INFO dfs.DataNode$DataXceiver: Receiving block blk_-2192382893903170466 src: /10.251.201.204:36915 dest: /10.251.201.204:50010
+081110 123040 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.203.149:50010 is added to blk_-6247364168500873179 size 67108864
+081110 123114 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.125.237:50010 is added to blk_4234385041723406944 size 67108864
+081110 123132 11170 INFO dfs.DataNode$PacketResponder: Received block blk_8968608251219902913 of size 67108864 from /10.251.195.52
+081110 123237 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.10.100:50010 is added to blk_-8502460962248995911 size 28489733
+081110 123252 11126 INFO dfs.DataNode$PacketResponder: Received block blk_-1201318815778694289 of size 67108864 from /10.251.194.147
+081110 123252 11243 INFO dfs.DataNode$PacketResponder: Received block blk_-9089815063425241739 of size 67108864 from /10.251.126.255
+081110 123309 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.214.32:50010 is added to blk_1389634598105954660 size 67108864
+081110 123401 10856 INFO dfs.DataNode$PacketResponder: Received block blk_557803157214911261 of size 67108864 from /10.251.198.196
+081110 123453 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.42.9:50010 is added to blk_-1435656632270396446 size 28490269
+081110 123517 11398 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_7345322407792942877 terminating
+081110 123541 11406 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-8939321760994370713 terminating
+081110 123543 11010 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_3958940914408609637 terminating
+081110 123726 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt2/_temporary/_task_200811101024_0002_m_001968_1/part-01968. blk_5106303344783117537
+081110 123810 11328 INFO dfs.DataNode$DataXceiver: Receiving block blk_6628512193350164674 src: /10.251.73.220:33460 dest: /10.251.73.220:50010
+081110 123827 11309 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-5587827566367944828 terminating
+081110 124158 11529 INFO dfs.DataNode$DataXceiver: 10.250.11.53:50010 Served block blk_-743349875664670637 to /10.250.11.53
+081110 124159 11369 WARN dfs.DataNode$DataXceiver: 10.251.70.5:50010:Got exception while serving blk_4581070264530964999 to /10.250.13.188:
+081110 124817 11533 WARN dfs.DataNode$DataXceiver: 10.251.74.79:50010:Got exception while serving blk_2139707931694085102 to /10.251.111.228:
+081110 125138 11558 WARN dfs.DataNode$DataXceiver: 10.251.42.246:50010:Got exception while serving blk_-3056652732896088330 to /10.251.27.63:
+081110 125914 11536 WARN dfs.DataNode$DataXceiver: 10.250.13.188:50010:Got exception while serving blk_73389299186801686 to /10.251.123.33:
+081110 125920 11517 WARN dfs.DataNode$DataXceiver: 10.251.42.16:50010:Got exception while serving blk_4963214289850966664 to /10.251.202.181:
+081110 130315 11823 WARN dfs.DataNode$DataXceiver: 10.251.71.240:50010:Got exception while serving blk_-8082428389627750477 to /10.251.71.97:
+081110 130558 11608 INFO dfs.DataNode$DataXceiver: 10.251.39.192:50010 Served block blk_6338761369201338121 to /10.251.90.81
+081110 131041 11754 WARN dfs.DataNode$DataXceiver: 10.251.122.38:50010:Got exception while serving blk_7489155602821840025 to /10.251.26.8:
+081110 131128 11976 INFO dfs.DataNode$DataXceiver: 10.251.67.225:50010 Served block blk_2038610753592374847 to /10.250.18.114
+081110 131233 11867 WARN dfs.DataNode$DataXceiver: 10.251.197.226:50010:Got exception while serving blk_2101007907134483259 to /10.251.31.242:
+081110 131806 11757 WARN dfs.DataNode$DataXceiver: 10.251.26.177:50010:Got exception while serving blk_3848747149919646864 to /10.251.125.174:
+081110 131950 11797 WARN dfs.DataNode$DataXceiver: 10.251.30.85:50010:Got exception while serving blk_8059204889272489644 to /10.250.7.96:
+081110 132523 11832 WARN dfs.DataNode$DataXceiver: 10.251.39.179:50010:Got exception while serving blk_1683075246463470765 to /10.250.14.38:
+081110 133337 11768 INFO dfs.DataNode$DataXceiver: 10.250.10.100:50010 Served block blk_9216955386716663841 to /10.251.90.64
+081110 133657 11701 WARN dfs.DataNode$DataXceiver: 10.251.123.132:50010:Got exception while serving blk_4048438071314937575 to /10.251.194.213:
+081110 133823 11970 INFO dfs.DataNode$DataXceiver: 10.251.203.149:50010 Served block blk_-1432303681669932458 to /10.250.10.176
+081110 133946 11947 WARN dfs.DataNode$DataXceiver: 10.251.126.255:50010:Got exception while serving blk_1910039736720341651 to /10.251.31.85:
+081110 135429 12030 WARN dfs.DataNode$DataXceiver: 10.251.70.37:50010:Got exception while serving blk_1646534811870220828 to /10.250.11.100:
+081110 135645 13 INFO dfs.DataBlockScanner: Verification succeeded for blk_-4984504651603069357
+081110 135653 12034 WARN dfs.DataNode$DataXceiver: 10.251.214.130:50010:Got exception while serving blk_424461424221613461 to /10.251.71.193:
+081110 135803 12201 INFO dfs.DataNode$DataXceiver: 10.251.214.18:50010 Served block blk_7297060562345904886 to /10.251.29.239
+081110 135806 12060 WARN dfs.DataNode$DataXceiver: 10.251.215.70:50010:Got exception while serving blk_-7391656937286046074 to /10.251.107.196:
+081110 142841 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/sortrand2/_temporary/_task_200811101024_0003_r_000258_0/part-00258. blk_387577766066135394
+081110 143222 12360 INFO dfs.DataNode$DataXceiver: Receiving block blk_6107935679779418195 src: /10.251.43.115:55925 dest: /10.251.43.115:50010
+081110 143232 12469 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_3584162266158512993 terminating
+081110 143318 12458 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-2591043665372016488 terminating
+081110 143336 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/sortrand2/_temporary/_task_200811101024_0003_r_000257_0/part-00257. blk_-1732662141253491971
+081110 143353 12141 INFO dfs.DataNode$DataXceiver: Receiving block blk_4959462704623252283 src: /10.251.125.174:44166 dest: /10.251.125.174:50010
+081110 143430 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.7.96:50010 is added to blk_4553790855855864497 size 67108864
+081110 143551 12299 INFO dfs.DataNode$DataXceiver: Receiving block blk_-3261177124784025140 src: /10.251.29.239:43937 dest: /10.251.29.239:50010
+081110 143554 12294 INFO dfs.DataNode$PacketResponder: Received block blk_7501235595045510958 of size 67108864 from /10.251.214.67
+081110 143613 12543 INFO dfs.DataNode$DataXceiver: Receiving block blk_-3486808304671603275 src: /10.251.30.85:37518 dest: /10.251.30.85:50010
+081110 143651 12577 INFO dfs.DataNode$DataXceiver: Receiving block blk_6563909003697001371 src: /10.251.39.144:48872 dest: /10.251.39.144:50010
+081110 143725 12558 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_4068667188725811395 terminating
+081110 143736 12448 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7355153279766988632 src: /10.251.194.245:35876 dest: /10.251.194.245:50010
+081110 143920 12287 INFO dfs.DataNode$DataXceiver: Receiving block blk_-4854562124894030819 src: /10.250.10.100:40486 dest: /10.250.10.100:50010
+081110 143945 12653 INFO dfs.DataNode$PacketResponder: Received block blk_1828089683746536118 of size 67108864 from /10.250.6.223
+081110 144004 12354 INFO dfs.DataNode$DataXceiver: Receiving block blk_1345503778930512538 src: /10.251.75.163:40307 dest: /10.251.75.163:50010
+081110 144024 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.195.70:50010 is added to blk_4318179566727871532 size 67108864
+081110 144035 12577 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_727000711161641724 terminating
+081110 144100 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.123.33:50010 is added to blk_-2916658835497879256 size 67108864
+081110 144201 12384 INFO dfs.DataNode$PacketResponder: Received block blk_7227035060836018780 of size 67108864 from /10.250.5.237
+081110 144220 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.111.209:50010 is added to blk_4069436988023676023 size 67108864
+081110 144309 12287 INFO dfs.DataNode$PacketResponder: Received block blk_-3981735565440284420 of size 67108864 from /10.251.127.243
+081110 144404 12709 INFO dfs.DataNode$DataXceiver: Receiving block blk_728165942214842306 src: /10.251.30.179:57828 dest: /10.251.30.179:50010
+081110 144509 12519 INFO dfs.DataNode$DataXceiver: Receiving block blk_-3157541550945505354 src: /10.251.125.193:45917 dest: /10.251.125.193:50010
+081110 144546 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.27.63:50010 is added to blk_7838843222458775811 size 67108864
+081110 144547 12473 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_3088175971503531298 terminating
+081110 144643 12257 INFO dfs.DataNode$PacketResponder: Received block blk_-3620767662957963389 of size 67108864 from /10.251.203.179
+081110 144735 12785 INFO dfs.DataNode$DataXceiver: Receiving block blk_-5078186985701364847 src: /10.251.37.240:35757 dest: /10.251.37.240:50010
+081110 144750 12364 INFO dfs.DataNode$DataXceiver: Receiving block blk_7193551490488433552 src: /10.251.74.227:44191 dest: /10.251.74.227:50010
+081110 144848 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.66.102:50010 is added to blk_-8022986908643041177 size 67108864
+081110 144947 12810 INFO dfs.DataNode$DataXceiver: Receiving block blk_-5003122231679852524 src: /10.250.7.230:51033 dest: /10.250.7.230:50010
+081110 145021 12676 INFO dfs.DataNode$PacketResponder: Received block blk_-3276232266876914214 of size 67108864 from /10.250.7.146
+081110 145037 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/sortrand2/_temporary/_task_200811101024_0003_r_000210_0/part-00210. blk_-7667417209393167541
+081110 145114 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.31.242:50010 is added to blk_-5400783031085008882 size 67108864
+081110 145120 12820 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-1197396592032418307 terminating
+081110 145203 12416 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_7533949673910842243 terminating
+081110 145213 12875 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_8842097432176169457 terminating
+081110 145452 12780 INFO dfs.DataNode$PacketResponder: Received block blk_560063894682806537 of size 67108864 from /10.251.194.129
+081110 145506 12603 INFO dfs.DataNode$PacketResponder: Received block blk_2652444451422301232 of size 67108864 from /10.251.214.225
+081110 145606 12992 INFO dfs.DataNode$PacketResponder: Received block blk_7016884347337429710 of size 67108864 from /10.251.194.129
+081110 145606 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.26.131:50010 is added to blk_-4174618838156947380 size 67108864
+081110 145703 12721 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-3402248757106237109 terminating
+081110 145746 12982 INFO dfs.DataNode$DataXceiver: Receiving block blk_-8915123233040672605 src: /10.250.10.176:58294 dest: /10.250.10.176:50010
+081110 145749 12962 INFO dfs.DataNode$PacketResponder: Received block blk_-5633587983998853189 of size 67108864 from /10.251.73.220
+081110 145818 12949 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_2570966823909513791 terminating
+081110 145931 12812 INFO dfs.DataNode$PacketResponder: Received block blk_-6168484338203583997 of size 67108864 from /10.251.39.192
+081110 145944 12814 INFO dfs.DataNode$DataXceiver: Receiving block blk_-3172594752427649592 src: /10.251.198.196:57807 dest: /10.251.198.196:50010
+081110 150009 12830 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_8285441926344578159 terminating
+081110 150125 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.71.193:50010 is added to blk_7415823309220171667 size 67108864
+081110 150205 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/sortrand2/_temporary/_task_200811101024_0003_r_000116_0/part-00116. blk_6749232449432458524
+081110 150238 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.38.197:50010 is added to blk_-5427918313707752877 size 67108864
+081110 150240 12700 INFO dfs.DataNode$DataXceiver: Receiving block blk_-4673509946769671609 src: /10.251.30.85:34022 dest: /10.251.30.85:50010
+081110 150254 13 INFO dfs.DataBlockScanner: Verification succeeded for blk_-7803343374223161433
+081110 150316 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.105.189:50010 is added to blk_-3275237990609680332 size 67108864
+081110 150436 13158 INFO dfs.DataNode$DataXceiver: Receiving block blk_-8584158329012779023 src: /10.250.19.16:50122 dest: /10.250.19.16:50010
+081110 150455 13155 INFO dfs.DataNode$DataXceiver: Receiving block blk_-4468166796563085237 src: /10.251.215.50:53705 dest: /10.251.215.50:50010
+081110 150531 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/sortrand2/_temporary/_task_200811101024_0003_r_000315_0/part-00315. blk_-463998587096565542
+081110 150600 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.73.220:50010 is added to blk_578261619176233743 size 67108864
+081110 150618 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.73.188:50010 is added to blk_-3897674589140998025 size 67108864
+081110 150751 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.17.225:50010 is added to blk_-3573208405519699182 size 67108864
+081110 150809 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.214.67:50010 is added to blk_4154740411570608045 size 67108864
+081110 150933 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.203.179:50010 is added to blk_8188837227311063557 size 67108864
+081110 151115 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.42.191:50010 is added to blk_-4208396523159735354 size 67108864
+081110 151202 13109 INFO dfs.DataNode$DataXceiver: Receiving block blk_7572868180557515526 src: /10.251.214.130:38983 dest: /10.251.214.130:50010
+081110 151229 13144 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-1733803097614960767 terminating
+081110 151307 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/sortrand2/_temporary/_task_200811101024_0003_r_000152_0/part-00152. blk_-7603795308074215276
+081110 151427 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/sortrand2/_temporary/_task_200811101024_0003_r_000344_0/part-00344. blk_-2004529166303428909
+081110 151503 13083 INFO dfs.DataNode$DataXceiver: Receiving block blk_-5817942497672492100 src: /10.251.107.19:35639 dest: /10.251.107.19:50010
+081110 151558 13270 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-7512746652453970810 terminating
+081110 151600 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.75.143:50010 is added to blk_2618566506268332756 size 67108864
+081110 151717 12949 INFO dfs.DataNode$PacketResponder: Received block blk_-265588615173040885 of size 67108864 from /10.251.215.70
+081110 151902 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.13.188:50010 is added to blk_5971534893446541111 size 67108864
+081110 151940 12996 INFO dfs.DataNode$DataXceiver: Receiving block blk_4742178675580222210 src: /10.251.42.9:60232 dest: /10.251.42.9:50010
+081110 152137 13387 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-900229825899812461 terminating
+081110 152147 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.70.37:50010 is added to blk_300967862449910205 size 67108864
+081110 152215 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.19.227:50010 is added to blk_2059389709317340334 size 67108864
+081110 152240 13092 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-6865167803683277211 terminating
+081110 152613 13407 INFO dfs.DataNode$DataXceiver: Receiving block blk_1321799290531408498 src: /10.251.126.255:43447 dest: /10.251.126.255:50010
+081110 153301 13 INFO dfs.DataBlockScanner: Verification succeeded for blk_-8507209254958698084
+081110 153917 13338 INFO dfs.DataNode$PacketResponder: Received block blk_-7716943410942322104 of size 67108864 from /10.251.126.5
+081110 155142 13655 INFO dfs.DataNode$DataXceiver: Receiving block blk_-6884056342993438262 src: /10.251.193.175:46638 dest: /10.251.193.175:50010
+081110 160100 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.70.5:50010 is added to blk_-4092973201423074374 size 67108864
+081110 163007 13812 INFO dfs.DataNode$DataXceiver: 10.251.67.225:50010 Served block blk_5240632065631390212 to /10.251.67.225
+081110 163625 13543 INFO dfs.DataNode$DataXceiver: 10.251.106.50:50010 Served block blk_-8907436477337775860 to /10.251.106.50
+081110 163945 13711 WARN dfs.DataNode$DataXceiver: 10.251.30.101:50010:Got exception while serving blk_-5340885607150360719 to /10.251.30.101:
+081110 170322 13709 WARN dfs.DataNode$DataXceiver: 10.251.195.33:50010:Got exception while serving blk_6702054389824523327 to /10.251.195.33:
+081110 173556 13687 INFO dfs.DataNode$DataXceiver: 10.251.194.147:50010 Served block blk_7703498406755483188 to /10.251.111.209
+081110 173657 13 INFO dfs.DataBlockScanner: Verification succeeded for blk_2904134648927436267
+081110 175354 14021 WARN dfs.DataNode$DataXceiver: 10.250.11.53:50010:Got exception while serving blk_-7125370327234065733 to /10.250.15.240:
+081110 175426 13827 INFO dfs.DataNode$DataXceiver: 10.251.202.209:50010 Served block blk_-5086369325828333421 to /10.251.194.213
+081110 175818 13937 WARN dfs.DataNode$DataXceiver: 10.250.10.223:50010:Got exception while serving blk_8478683141242372735 to /10.251.70.5:
+081110 175826 14005 INFO dfs.DataNode$DataXceiver: 10.251.215.50:50010 Served block blk_668295516093167045 to /10.251.30.6
+081110 175934 12298 WARN dfs.DataNode$DataXceiver: 10.251.107.50:50010:Got exception while serving blk_-4737948505610037427 to /10.251.75.79:
+081110 183200 13 INFO dfs.DataBlockScanner: Verification succeeded for blk_1584196996810164915
+081110 190333 13 INFO dfs.DataBlockScanner: Verification succeeded for blk_1150231966878829887
+081110 191403 14120 WARN dfs.DataNode$DataXceiver: 10.250.14.196:50010:Got exception while serving blk_2967299761311489673 to /10.251.89.155:
+081110 192015 14269 WARN dfs.DataNode$DataXceiver: 10.250.10.223:50010:Got exception while serving blk_9095955277706686312 to /10.250.5.161:
+081110 193334 14294 WARN dfs.DataNode$DataXceiver: 10.251.39.179:50010:Got exception while serving blk_-8558281124275910849 to /10.251.30.134:
+081110 193551 14191 INFO dfs.DataNode$DataXceiver: 10.251.71.97:50010 Served block blk_6552418180158772377 to /10.251.39.242
+081110 194159 14349 WARN dfs.DataNode$DataXceiver: 10.251.26.8:50010:Got exception while serving blk_-3572295706132449090 to /10.251.111.130:
+081110 194544 14270 INFO dfs.DataNode$DataXceiver: 10.251.202.209:50010 Served block blk_-1442905060580014339 to /10.251.202.209
+081110 194735 14044 WARN dfs.DataNode$DataXceiver: 10.251.127.243:50010:Got exception while serving blk_7760079751081658559 to /10.251.215.70:
+081110 195500 14389 INFO dfs.DataNode$DataXceiver: 10.251.39.179:50010 Served block blk_798664047382151445 to /10.251.39.179
+081110 200311 14622 INFO dfs.DataNode$DataXceiver: 10.250.11.194:50010 Served block blk_8591104451552720112 to /10.250.11.194
+081110 210112 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-531469051872229488 is added to invalidSet of 10.251.71.146:50010
+081110 210115 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-4657423175636611807 is added to invalidSet of 10.251.193.175:50010
+081110 210115 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-6117917602803602155 is added to invalidSet of 10.251.67.211:50010
+081110 210115 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-7584542530081657301 is added to invalidSet of 10.250.10.223:50010
+081110 210118 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_4640277741339926850 is added to invalidSet of 10.251.26.131:50010
+081110 210118 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-7285565997486715015 is added to invalidSet of 10.250.6.191:50010
+081110 210123 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_3652427357251545055 is added to invalidSet of 10.250.10.223:50010
+081110 210123 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_5163387277374142808 is added to invalidSet of 10.251.71.193:50010
+081110 210124 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-1342669964196815853 is added to invalidSet of 10.250.17.225:50010
+081110 210125 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-424018194735922479 is added to invalidSet of 10.251.42.84:50010
+081110 210126 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-3754029959138975487 is added to invalidSet of 10.251.214.112:50010
+081110 210126 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-4149539113118855204 is added to invalidSet of 10.251.71.16:50010
+081110 210126 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_5868517220927475394 is added to invalidSet of 10.251.67.113:50010
+081110 210127 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_6093858391888371854 is added to invalidSet of 10.251.42.207:50010
+081110 210128 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_7048740572660501729 is added to invalidSet of 10.251.107.98:50010
+081110 210129 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-2025578204394955498 is added to invalidSet of 10.251.91.159:50010
+081110 210129 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-795209964982424254 is added to invalidSet of 10.251.107.227:50010
+081110 210131 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_7606019272539977822 is added to invalidSet of 10.251.67.211:50010
+081110 210132 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_1960893136630391966 is added to invalidSet of 10.251.39.144:50010
+081110 210142 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-8632488927959646482 is added to invalidSet of 10.251.39.64:50010
+081110 210144 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_1302893891174665780 is added to invalidSet of 10.251.214.225:50010
+081110 210145 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-490230821467544285 is added to invalidSet of 10.250.10.6:50010
+081110 210146 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_4713968111267226537 is added to invalidSet of 10.251.70.5:50010
+081110 210146 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_7473411975130090672 is added to invalidSet of 10.251.75.143:50010
+081110 210147 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_753559000954836892 is added to invalidSet of 10.251.30.101:50010
+081110 210147 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_9085898147979939648 is added to invalidSet of 10.251.67.225:50010
+081110 210148 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-5403209762224435166 is added to invalidSet of 10.251.125.193:50010
+081110 210149 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-6932221506331060207 is added to invalidSet of 10.251.74.79:50010
+081110 210149 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-7693277678281547790 is added to invalidSet of 10.251.30.6:50010
+081110 210151 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_3792448673967861371 is added to invalidSet of 10.251.89.155:50010
+081110 210151 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_5496448884081025648 is added to invalidSet of 10.251.123.195:50010
+081110 210153 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_1102735311308675356 is added to invalidSet of 10.251.71.97:50010
+081110 210153 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_7094265091490664593 is added to invalidSet of 10.251.71.68:50010
+081110 210157 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-1271403908410292619 is added to invalidSet of 10.251.43.147:50010
+081110 210201 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-2439225174716664723 is added to invalidSet of 10.251.42.207:50010
+081110 210201 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-9220604860626391374 is added to invalidSet of 10.251.30.179:50010
+081110 210210 14441 INFO dfs.DataNode$DataXceiver: 10.250.15.101:50010 Served block blk_-2557432794238860908 to /10.251.74.134
+081110 210243 14482 INFO dfs.DataNode$PacketResponder: Received block blk_-8214089520956286311 of size 67108864 from /10.251.26.131
+081110 210252 18 INFO dfs.FSDataset: Deleting block blk_-8949548167466276130 file /mnt/hadoop/dfs/data/current/subdir2/blk_-8949548167466276130
+081110 210255 14644 INFO dfs.DataNode$DataXceiver: Receiving block blk_-4831379247767940447 src: /10.251.65.237:42885 dest: /10.251.65.237:50010
+081110 210259 19 INFO dfs.FSDataset: Deleting block blk_-7548149518969960333 file /mnt/hadoop/dfs/data/current/subdir8/blk_-7548149518969960333
+081110 210308 19 INFO dfs.FSDataset: Deleting block blk_-7353572928777348242 file /mnt/hadoop/dfs/data/current/subdir22/blk_-7353572928777348242
+081110 210330 19 INFO dfs.FSDataset: Deleting block blk_7206839389762980382 file /mnt/hadoop/dfs/data/current/subdir61/blk_7206839389762980382
+081110 210339 19 INFO dfs.FSDataset: Deleting block blk_-9171803179611497035 file /mnt/hadoop/dfs/data/current/subdir35/blk_-9171803179611497035
+081110 210354 19 INFO dfs.FSDataset: Deleting block blk_-4598246018559857954 file /mnt/hadoop/dfs/data/current/subdir34/blk_-4598246018559857954
+081110 210354 19 INFO dfs.FSDataset: Deleting block blk_-6901909114834172466 file /mnt/hadoop/dfs/data/current/subdir57/blk_-6901909114834172466
+081110 210401 19 INFO dfs.FSDataset: Deleting block blk_-6075803209168884005 file /mnt/hadoop/dfs/data/current/subdir31/blk_-6075803209168884005
+081110 210401 19 INFO dfs.FSDataset: Deleting block blk_-8617088607862430908 file /mnt/hadoop/dfs/data/current/subdir53/blk_-8617088607862430908
+081110 210403 14498 INFO dfs.DataNode$DataXceiver: Receiving block blk_7347539858784653625 src: /10.250.11.194:46600 dest: /10.250.11.194:50010
+081110 210404 19 INFO dfs.FSDataset: Deleting block blk_7855353385462032387 file /mnt/hadoop/dfs/data/current/subdir41/blk_7855353385462032387
+081110 210413 19 INFO dfs.FSDataset: Deleting block blk_3733339790842827121 file /mnt/hadoop/dfs/data/current/subdir42/blk_3733339790842827121
+081110 210417 19 INFO dfs.FSDataset: Deleting block blk_-9017308542351369260 file /mnt/hadoop/dfs/data/current/subdir14/blk_-9017308542351369260
+081110 210422 11315 INFO dfs.DataNode$PacketResponder: Received block blk_-3734839878416656496 of size 67108864 from /10.251.66.102
+081110 210423 19 INFO dfs.FSDataset: Deleting block blk_-8360774680830158225 file /mnt/hadoop/dfs/data/current/subdir31/blk_-8360774680830158225
+081110 210425 19 INFO dfs.FSDataset: Deleting block blk_-6942784423611603919 file /mnt/hadoop/dfs/data/current/subdir38/blk_-6942784423611603919
+081110 210427 19 INFO dfs.FSDataset: Deleting block blk_-5603192027616633151 file /mnt/hadoop/dfs/data/current/subdir34/blk_-5603192027616633151
+081110 210442 19 INFO dfs.FSDataset: Deleting block blk_-7854501109698465657 file /mnt/hadoop/dfs/data/current/subdir34/blk_-7854501109698465657
+081110 210449 19 INFO dfs.FSDataset: Deleting block blk_-4551689611865410817 file /mnt/hadoop/dfs/data/current/blk_-4551689611865410817
+081110 210450 19 INFO dfs.FSDataset: Deleting block blk_-1750007847201154657 file /mnt/hadoop/dfs/data/current/subdir1/blk_-1750007847201154657
+081110 210502 19 INFO dfs.FSDataset: Deleting block blk_-3564493590065542578 file /mnt/hadoop/dfs/data/current/subdir55/blk_-3564493590065542578
+081110 210509 18 INFO dfs.FSDataset: Deleting block blk_-2929627680703662712 file /mnt/hadoop/dfs/data/current/subdir32/blk_-2929627680703662712
+081110 210510 19 INFO dfs.FSDataset: Deleting block blk_2708206493147801743 file /mnt/hadoop/dfs/data/current/subdir15/blk_2708206493147801743
+081110 210511 19 INFO dfs.FSDataset: Deleting block blk_-4110699195744660699 file /mnt/hadoop/dfs/data/current/subdir34/blk_-4110699195744660699
+081110 210512 19 INFO dfs.FSDataset: Deleting block blk_7721951162137927252 file /mnt/hadoop/dfs/data/current/subdir52/blk_7721951162137927252
+081110 210515 19 INFO dfs.FSDataset: Deleting block blk_-1535908830476495455 file /mnt/hadoop/dfs/data/current/subdir10/blk_-1535908830476495455
+081110 210516 19 INFO dfs.FSDataset: Deleting block blk_1184972950286241114 file /mnt/hadoop/dfs/data/current/subdir39/blk_1184972950286241114
+081110 210517 19 INFO dfs.FSDataset: Deleting block blk_-3396836569886642130 file /mnt/hadoop/dfs/data/current/subdir32/blk_-3396836569886642130
+081110 210532 19 INFO dfs.FSDataset: Deleting block blk_22457656256024207 file /mnt/hadoop/dfs/data/current/subdir33/blk_22457656256024207
+081110 210534 19 INFO dfs.FSDataset: Deleting block blk_5905689738251144455 file /mnt/hadoop/dfs/data/current/blk_5905689738251144455
+081110 210537 19 INFO dfs.FSDataset: Deleting block blk_-2210703755506918304 file /mnt/hadoop/dfs/data/current/subdir26/blk_-2210703755506918304
+081110 210540 18 INFO dfs.FSDataset: Deleting block blk_773599351835388127 file /mnt/hadoop/dfs/data/current/subdir60/blk_773599351835388127
+081110 210540 19 INFO dfs.FSDataset: Deleting block blk_3921292580505776296 file /mnt/hadoop/dfs/data/current/subdir57/blk_3921292580505776296
+081110 210542 19 INFO dfs.FSDataset: Deleting block blk_4162832865986721185 file /mnt/hadoop/dfs/data/current/subdir4/blk_4162832865986721185
+081110 210545 19 INFO dfs.FSDataset: Deleting block blk_2156262111024914941 file /mnt/hadoop/dfs/data/current/subdir14/blk_2156262111024914941
+081110 210548 19 INFO dfs.FSDataset: Deleting block blk_4658551441818960395 file /mnt/hadoop/dfs/data/current/subdir19/blk_4658551441818960395
+081110 210549 19 INFO dfs.FSDataset: Deleting block blk_3076992299328673559 file /mnt/hadoop/dfs/data/current/subdir54/blk_3076992299328673559
+081110 210549 19 INFO dfs.FSDataset: Deleting block blk_6085442148007558065 file /mnt/hadoop/dfs/data/current/subdir63/blk_6085442148007558065
+081110 210555 19 INFO dfs.FSDataset: Deleting block blk_1746384029810476219 file /mnt/hadoop/dfs/data/current/subdir18/blk_1746384029810476219
+081110 210555 19 INFO dfs.FSDataset: Deleting block blk_4939101994162863442 file /mnt/hadoop/dfs/data/current/subdir24/blk_4939101994162863442
+081110 210558 19 INFO dfs.FSDataset: Deleting block blk_1144571179430079218 file /mnt/hadoop/dfs/data/current/subdir33/blk_1144571179430079218
+081110 210558 19 INFO dfs.FSDataset: Deleting block blk_8693774866554287286 file /mnt/hadoop/dfs/data/current/subdir55/blk_8693774866554287286
+081110 210600 18 INFO dfs.FSDataset: Deleting block blk_6695517786834913217 file /mnt/hadoop/dfs/data/current/subdir15/blk_6695517786834913217
+081110 210601 19 INFO dfs.FSDataset: Deleting block blk_70980361971054326 file /mnt/hadoop/dfs/data/current/subdir27/blk_70980361971054326
+081110 210608 19 INFO dfs.FSDataset: Deleting block blk_6499414220139660338 file /mnt/hadoop/dfs/data/current/subdir59/blk_6499414220139660338
+081110 210620 19 INFO dfs.FSDataset: Deleting block blk_8598135237831029828 file /mnt/hadoop/dfs/data/current/subdir59/blk_8598135237831029828
+081110 210640 19 INFO dfs.FSDataset: Deleting block blk_7108974241330205218 file /mnt/hadoop/dfs/data/current/subdir22/blk_7108974241330205218
+081110 210704 19 INFO dfs.FSDataset: Deleting block blk_8929806114713265094 file /mnt/hadoop/dfs/data/current/subdir1/blk_8929806114713265094
+081110 210710 19 INFO dfs.FSDataset: Deleting block blk_6445339027653789144 file /mnt/hadoop/dfs/data/current/subdir16/blk_6445339027653789144
+081110 210721 14857 INFO dfs.DataNode$DataXceiver: Receiving block blk_3235988328669699941 src: /10.251.199.159:43276 dest: /10.251.199.159:50010
+081110 210737 19 INFO dfs.FSDataset: Deleting block blk_8699831307500970779 file /mnt/hadoop/dfs/data/current/subdir54/blk_8699831307500970779
+081110 210753 19 INFO dfs.FSDataset: Deleting block blk_3221204570666147236 file /mnt/hadoop/dfs/data/current/subdir34/blk_3221204570666147236
+081110 210832 14473 INFO dfs.DataNode$DataXceiver: Receiving block blk_-5808893254440551816 src: /10.250.11.194:53256 dest: /10.250.11.194:50010
+081110 210837 14418 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_3940282600163903101 terminating
+081110 211021 14407 INFO dfs.DataNode$DataXceiver: Receiving block blk_4233013542759682998 src: /10.251.109.209:48041 dest: /10.251.109.209:50010
+081110 211030 19 INFO dfs.FSDataset: Deleting block blk_7360639743953947587 file /mnt/hadoop/dfs/data/current/subdir35/blk_7360639743953947587
+081110 211108 14882 INFO dfs.DataNode$PacketResponder: Received block blk_4182287230523664560 of size 67108864 from /10.251.111.130
+081110 211109 14620 INFO dfs.DataNode$DataXceiver: Receiving block blk_995094303184954394 src: /10.251.91.84:35590 dest: /10.251.91.84:50010
+081110 211122 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.30.6:50010 is added to blk_3585424189730250601 size 67108864
+081110 211131 14600 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-5680441982827916621 terminating
+081110 211323 14609 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_2089955821703690032 terminating
+081110 211355 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.106.10:50010 is added to blk_1151012386083696649 size 67108864
+081110 211358 14754 INFO dfs.DataNode$DataXceiver: Receiving block blk_4149909442914612270 src: /10.251.195.33:55490 dest: /10.251.195.33:50010
+081110 211410 14947 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_2282833575688432184 terminating
+081110 211504 14451 INFO dfs.DataNode$PacketResponder: Received block blk_3960527526103274525 of size 67108864 from /10.251.30.134
+081110 211523 14688 INFO dfs.DataNode$DataXceiver: Receiving block blk_-852118157909078164 src: /10.251.30.101:57254 dest: /10.251.30.101:50010
+081110 211541 18 INFO dfs.DataNode: 10.250.15.198:50010 Starting thread to transfer block blk_4292382298896622412 to 10.250.15.240:50010
+081110 211737 14817 INFO dfs.DataNode$PacketResponder: Received block blk_-185994527242886002 of size 3552954 from /10.251.39.160
+081110 211845 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.73.188:50010 is added to blk_8761786041973172187 size 67108864
+081110 211926 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.70.211:50010 is added to blk_-5471660287004025096 size 67108864
+081110 212039 14833 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_3755116621101133849 terminating
+081110 212051 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.39.144:50010 is added to blk_-5542336029922582303 size 67108864
+081110 212111 14543 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_165707910410871749 terminating
+081110 212139 14759 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_2957756905007569214 terminating
+081110 212221 15037 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_4884219613602801814 terminating
+081110 212234 14745 INFO dfs.DataNode$PacketResponder: Received block blk_6698851413708497072 of size 67108864 from /10.251.74.134
+081110 212249 14727 INFO dfs.DataNode$PacketResponder: Received block blk_6730979070070986233 of size 67108864 from /10.251.90.239
+081110 212258 19 INFO dfs.FSDataset: Deleting block blk_-468830939205980722 file /mnt/hadoop/dfs/data/current/subdir10/blk_-468830939205980722
+081110 212312 15013 INFO dfs.DataNode$PacketResponder: Received block blk_-7056746602297676104 of size 67108864 from /10.251.39.209
+081110 212329 14784 INFO dfs.DataNode$DataXceiver: Receiving block blk_8473858691873523269 src: /10.250.11.53:60609 dest: /10.250.11.53:50010
+081110 212501 15023 INFO dfs.DataNode$PacketResponder: Received block blk_6686361711974377273 of size 3554889 from /10.251.214.130
+081110 212509 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.123.33:50010 is added to blk_-6442394521537090621 size 67108864
+081110 212510 19 INFO dfs.FSNamesystem: BLOCK* ask 10.250.18.114:50010 to delete  blk_-5140072410813878235
+081110 212556 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.91.84:50010 is added to blk_6039898256291822367 size 67108864
+081110 212644 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand3/_temporary/_task_200811101024_0005_m_000720_0/part-00720. blk_-7988596544606686086
+081110 212831 14962 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_5729560286355779655 terminating
+081110 212851 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.126.5:50010 is added to blk_-989798817617753264 size 67108864
+081110 212942 15258 INFO dfs.DataNode$PacketResponder: Received block blk_-2242088550278361724 of size 67108864 from /10.251.123.20
+081110 213021 15065 INFO dfs.DataNode$PacketResponder: Received block blk_5602895463700536678 of size 67108864 from /10.251.30.179
+081110 213026 15051 INFO dfs.DataNode$DataXceiver: Receiving block blk_7580930377559819562 src: /10.251.110.68:54793 dest: /10.251.110.68:50010
+081110 213221 15038 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_429279891070363457 terminating
+081110 213334 15049 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-9132218772786220159 terminating
+081110 213351 15202 INFO dfs.DataNode$DataXceiver: Receiving block blk_-2901266958756042716 src: /10.251.110.160:35787 dest: /10.251.110.160:50010
+081110 213423 14805 INFO dfs.DataNode$PacketResponder: Received block blk_6323743466920239525 of size 67108864 from /10.250.15.67
+081110 213434 15194 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-7948158002985968470 terminating
+081110 213448 15242 INFO dfs.DataNode$DataXceiver: Receiving block blk_-8974021306351083168 src: /10.251.91.15:40699 dest: /10.251.91.15:50010
+081110 213534 15015 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-4917866339076366459 terminating
+081110 213723 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.214.112:50010 is added to blk_8063831442998721547 size 67108864
+081110 213816 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand3/_temporary/_task_200811101024_0005_m_001091_0/part-01091. blk_-4468645577339843974
+081110 213828 15327 INFO dfs.DataNode$DataXceiver: Receiving block blk_9121519145462575118 src: /10.250.10.223:58281 dest: /10.250.10.223:50010
+081110 213833 15315 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-6773301007994789531 terminating
+081110 213854 15334 INFO dfs.DataNode$DataXceiver: Receiving block blk_-878226404201600469 src: /10.250.7.96:40849 dest: /10.250.7.96:50010
+081110 213959 15103 INFO dfs.DataNode$PacketResponder: Received block blk_-6031720401337601269 of size 67108864 from /10.250.10.100
+081110 214044 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.198.33:50010 is added to blk_-5159573936338473350 size 67108864
+081110 214101 15116 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-703436021914343546 terminating
+081110 214117 15141 INFO dfs.DataNode$PacketResponder: Received block blk_-8641647081502666269 of size 67108864 from /10.250.10.100
+081110 214226 15186 INFO dfs.DataNode$DataXceiver: Receiving block blk_3542047035353248258 src: /10.250.6.214:59051 dest: /10.250.6.214:50010
+081110 214321 15339 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-736188013503336717 terminating
+081110 214404 15111 INFO dfs.DataNode$PacketResponder: Received block blk_1188202922232921994 of size 67108864 from /10.250.10.100
+081110 214525 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.195.33:50010 is added to blk_-9049344623659872649 size 67108864
+081110 214634 15356 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_4575129504644372394 terminating
+081110 214823 15099 INFO dfs.DataNode$DataXceiver: Receiving block blk_8574493302165689212 src: /10.251.194.245:34656 dest: /10.251.194.245:50010
+081110 214907 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.107.19:50010 is added to blk_5574898547439146021 size 67108864
+081110 215003 15501 INFO dfs.DataNode$PacketResponder: Received block blk_2474460483915499078 of size 67108864 from /10.251.195.52
+081110 215057 15637 INFO dfs.DataNode$PacketResponder: Received block blk_7851643274522055587 of size 67108864 from /10.251.214.112
+081110 215111 15220 INFO dfs.DataNode$PacketResponder: Received block blk_8097409435735325492 of size 67108864 from /10.251.111.209
+081110 215117 15436 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-966013175018359901 terminating
+081110 215253 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand3/_temporary/_task_200811101024_0005_m_001655_0/part-01655. blk_-6802153775367591521
+081110 215310 15040 INFO dfs.DataNode$PacketResponder: Received block blk_-3300851862683571086 of size 67108864 from /10.251.203.166
+081110 215310 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.105.189:50010 is added to blk_-2035996502664501008 size 67108864
+081110 215357 15296 INFO dfs.DataNode$DataXceiver: Receiving block blk_8222237992861447018 src: /10.251.203.4:60086 dest: /10.251.203.4:50010
+081110 215546 15564 INFO dfs.DataNode$DataXceiver: Receiving block blk_6556854018013706836 src: /10.251.202.134:48721 dest: /10.251.202.134:50010
+081110 215546 15644 INFO dfs.DataNode$PacketResponder: Received block blk_8302956190102508375 of size 67108864 from /10.251.109.236
+081110 215654 15437 INFO dfs.DataNode$DataXceiver: Receiving block blk_-2583370070230800221 src: /10.251.31.160:58714 dest: /10.251.31.160:50010
+081110 215722 15450 INFO dfs.DataNode$DataXceiver: Receiving block blk_392347292517057138 src: /10.251.31.160:58721 dest: /10.251.31.160:50010
+081110 215726 15711 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_1639683981444528748 terminating
+081110 215726 15721 INFO dfs.DataNode$DataXceiver: Receiving block blk_5525607749827896334 src: /10.251.66.102:33326 dest: /10.251.66.102:50010
+081110 215806 15819 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_6809155287484296510 terminating
+081110 215813 15758 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-5908283405801966540 terminating
+081110 215817 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand3/_temporary/_task_200811101024_0005_m_001824_0/part-01824. blk_-4654885003331291932
+081110 220009 15450 INFO dfs.DataNode$PacketResponder: Received block blk_-8923698979247229952 of size 67108864 from /10.251.90.239
+081110 220042 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.91.84:50010 is added to blk_-2321016155994168744 size 67108864
+081110 220148 15613 INFO dfs.DataNode$PacketResponder: Received block blk_-2151458111813215098 of size 67108864 from /10.250.9.207
+081110 220238 15679 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-1733154814375651491 terminating
+081110 220312 15681 INFO dfs.DataNode$DataXceiver: Receiving block blk_-3187293586306086277 src: /10.251.35.1:50933 dest: /10.251.35.1:50010
+081110 220314 15849 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7914996925059840931 src: /10.251.91.15:59714 dest: /10.251.91.15:50010
+081110 220350 15848 INFO dfs.DataNode$PacketResponder: Received block blk_5379939266348893280 of size 67108864 from /10.251.66.63
+081110 220626 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_8981795097778421111 is added to invalidSet of 10.251.194.129:50010
+081110 220630 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_1979447750586388860 is added to invalidSet of 10.251.215.192:50010
+081110 220636 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_3332848207645320273 is added to invalidSet of 10.251.90.64:50010
+081110 220636 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_6881216037013929188 is added to invalidSet of 10.251.91.32:50010
+081110 220637 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_7541621664406141215 is added to invalidSet of 10.251.214.32:50010
+081110 220645 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-1680175975862749862 is added to invalidSet of 10.250.14.38:50010
+081110 220646 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_5176179471361959897 is added to invalidSet of 10.250.9.207:50010
+081110 220648 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-4385347171136037814 is added to invalidSet of 10.251.67.113:50010
+081110 220648 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_8384329882986724706 is added to invalidSet of 10.251.123.195:50010
+081110 220650 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_6392434729242722288 is added to invalidSet of 10.251.30.134:50010
+081110 220651 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_1714886759174770356 is added to invalidSet of 10.251.31.5:50010
+081110 220651 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_7400944190976416273 is added to invalidSet of 10.251.127.243:50010
+081110 220651 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_8442157310069672329 is added to invalidSet of 10.251.39.64:50010
+081110 220653 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-5624558200776510955 is added to invalidSet of 10.251.107.242:50010
+081110 220655 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_1481009974400305784 is added to invalidSet of 10.251.39.242:50010
+081110 220655 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_355286618997526877 is added to invalidSet of 10.250.7.32:50010
+081110 220655 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-7369651436133452001 is added to invalidSet of 10.251.127.191:50010
+081110 220656 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-8353423262983821010 is added to invalidSet of 10.251.39.209:50010

--- a/logs/HDFS/HDFS_1k_2.log
+++ b/logs/HDFS/HDFS_1k_2.log
@@ -1,0 +1,1000 @@
+081110 220658 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_7017399031777870797 is added to invalidSet of 10.250.5.161:50010
+081110 220708 19 INFO dfs.FSDataset: Deleting block blk_-6891122177443047531 file /mnt/hadoop/dfs/data/current/subdir36/blk_-6891122177443047531
+081110 220711 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt3/_temporary/_task_200811101024_0007_m_000190_0/part-00190. blk_641646158310569454
+081110 220749 19 INFO dfs.FSDataset: Deleting block blk_-9171930401624803515 file /mnt/hadoop/dfs/data/current/subdir56/blk_-9171930401624803515
+081110 220801 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.42.84:50010 is added to blk_5938666289587069744 size 67108864
+081110 220804 19 INFO dfs.FSDataset: Deleting block blk_-8294986551316947211 file /mnt/hadoop/dfs/data/current/subdir34/blk_-8294986551316947211
+081110 220811 19 INFO dfs.FSDataset: Deleting block blk_-5718504625725408070 file /mnt/hadoop/dfs/data/current/blk_-5718504625725408070
+081110 220830 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt3/_temporary/_task_200811101024_0007_m_000374_0/part-00374. blk_-1941312615450572331
+081110 220853 19 INFO dfs.FSDataset: Deleting block blk_2353918919834315845 file /mnt/hadoop/dfs/data/current/subdir35/blk_2353918919834315845
+081110 220907 19 INFO dfs.FSDataset: Deleting block blk_391507259220628397 file /mnt/hadoop/dfs/data/current/blk_391507259220628397
+081110 220909 19 INFO dfs.FSDataset: Deleting block blk_-1263913006422225885 file /mnt/hadoop/dfs/data/current/subdir2/blk_-1263913006422225885
+081110 220911 19 INFO dfs.FSDataset: Deleting block blk_6542592144596063478 file /mnt/hadoop/dfs/data/current/subdir35/blk_6542592144596063478
+081110 220916 15860 INFO dfs.DataNode$DataXceiver: Receiving block blk_-4473277914543734578 src: /10.251.215.16:34762 dest: /10.251.215.16:50010
+081110 220921 19 INFO dfs.FSDataset: Deleting block blk_1689772850125323349 file /mnt/hadoop/dfs/data/current/subdir27/blk_1689772850125323349
+081110 220923 19 INFO dfs.FSDataset: Deleting block blk_8615522912610884162 file /mnt/hadoop/dfs/data/current/subdir35/blk_8615522912610884162
+081110 220925 19 INFO dfs.FSDataset: Deleting block blk_107727140948970996 file /mnt/hadoop/dfs/data/current/subdir33/blk_107727140948970996
+081110 220936 19 INFO dfs.FSDataset: Deleting block blk_-1598760065436384831 file /mnt/hadoop/dfs/data/current/subdir53/blk_-1598760065436384831
+081110 220955 19 INFO dfs.FSDataset: Deleting block blk_8950932638808086257 file /mnt/hadoop/dfs/data/current/subdir18/blk_8950932638808086257
+081110 221033 15695 INFO dfs.DataNode$PacketResponder: Received block blk_-8835758154471700679 of size 67108864 from /10.251.73.188
+081110 221038 16067 INFO dfs.DataNode$DataXceiver: Receiving block blk_323887415551221572 src: /10.251.39.144:46278 dest: /10.251.39.144:50010
+081110 221125 15347 INFO dfs.DataNode$PacketResponder: Received block blk_231502148921342925 of size 67108864 from /10.251.215.192
+081110 221134 16153 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_1349228381785843634 terminating
+081110 221212 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt3/_temporary/_task_200811101024_0007_m_000186_0/part-00186. blk_-6754647973871368247
+081110 221253 15107 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7539658633533020967 src: /10.250.5.161:52151 dest: /10.250.5.161:50010
+081110 221343 15521 INFO dfs.DataNode$PacketResponder: Received block blk_6406847509870023726 of size 67108864 from /10.251.106.50
+081110 221447 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.43.115:50010 is added to blk_-7893636450787030202 size 67108864
+081110 221653 15684 INFO dfs.DataNode$PacketResponder: Received block blk_-5777981614298940026 of size 67108864 from /10.251.214.67
+081110 221803 15957 INFO dfs.DataNode$PacketResponder: Received block blk_4231049049582051919 of size 28496610 from /10.250.19.227
+081110 221932 19 INFO dfs.FSNamesystem: BLOCK* ask 10.251.122.79:50010 to delete  blk_8048594464172649365
+081110 221943 15858 INFO dfs.DataNode$DataXceiver: Receiving block blk_4414644179961808738 src: /10.251.107.98:46161 dest: /10.251.107.98:50010
+081110 222039 16041 INFO dfs.DataNode$DataXceiver: Receiving block blk_7661189768086976193 src: /10.251.195.52:56915 dest: /10.251.195.52:50010
+081110 222052 16100 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-7170175035335391571 terminating
+081110 222130 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.15.198:50010 is added to blk_4992622607400168655 size 67108864
+081110 222221 15824 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_8971893898579544235 terminating
+081110 222321 16072 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7418372263556457716 src: /10.251.89.155:53560 dest: /10.251.89.155:50010
+081110 222413 16030 INFO dfs.DataNode$DataXceiver: Receiving block blk_-3417101330634563680 src: /10.251.110.68:44200 dest: /10.251.110.68:50010
+081110 222455 16220 INFO dfs.DataNode$PacketResponder: Received block blk_4294115716822011564 of size 67108864 from /10.251.43.210
+081110 222459 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.39.160:50010 is added to blk_1865953191447352631 size 67108864
+081110 222511 16129 INFO dfs.DataNode$DataXceiver: Receiving block blk_2147212041377545584 src: /10.251.75.49:34485 dest: /10.251.75.49:50010
+081110 222512 16222 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_708101772844351082 terminating
+081110 222529 15925 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-5610308397633191834 terminating
+081110 222621 16005 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-7159695919045792245 terminating
+081110 222712 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.71.68:50010 is added to blk_8850044049297409379 size 67108864
+081110 222946 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt3/_temporary/_task_200811101024_0007_m_000585_0/part-00585. blk_8561332122820208519
+081110 222948 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.67.113:50010 is added to blk_-8393060055740236791 size 67108864
+081110 222951 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.122.38:50010 is added to blk_-5861348317118763621 size 28500222
+081110 223000 16174 INFO dfs.DataNode$PacketResponder: Received block blk_5174461779237739025 of size 67108864 from /10.250.14.143
+081110 223002 15950 INFO dfs.DataNode$DataXceiver: Receiving block blk_1463530401988623658 src: /10.251.111.37:41293 dest: /10.251.111.37:50010
+081110 223032 16147 INFO dfs.DataNode$PacketResponder: Received block blk_-8377763431920892140 of size 67108864 from /10.250.6.223
+081110 223108 16252 INFO dfs.DataNode$DataXceiver: Receiving block blk_-1728983474612515818 src: /10.251.70.211:39459 dest: /10.251.70.211:50010
+081110 223140 15976 INFO dfs.DataNode$DataXceiver: Receiving block blk_8007544297333060851 src: /10.251.90.134:47340 dest: /10.251.90.134:50010
+081110 223206 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.7.230:50010 is added to blk_6238543795209416553 size 67108864
+081110 223311 16266 INFO dfs.DataNode$DataXceiver: Receiving block blk_4599950495841528213 src: /10.251.194.102:59433 dest: /10.251.194.102:50010
+081110 223410 16237 INFO dfs.DataNode$PacketResponder: Received block blk_-8524952715666214329 of size 67108864 from /10.251.90.64
+081110 223615 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.127.243:50010 is added to blk_-5882295985950637419 size 67108864
+081110 223623 16188 INFO dfs.DataNode$PacketResponder: Received block blk_-1485109068671160157 of size 67108864 from /10.251.71.68
+081110 223802 15593 INFO dfs.DataNode$PacketResponder: Received block blk_3586596428873150919 of size 67108864 from /10.251.26.131
+081110 223833 16297 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7815259387557421424 src: /10.250.13.240:50649 dest: /10.250.13.240:50010
+081110 223849 16493 INFO dfs.DataNode$DataXceiver: Receiving block blk_3358274959811806117 src: /10.251.106.214:51334 dest: /10.251.106.214:50010
+081110 223854 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.90.239:50010 is added to blk_-5927343391895571936 size 67108864
+081110 223905 16320 INFO dfs.DataNode$DataXceiver: Receiving block blk_8907528844412790999 src: /10.251.126.227:42572 dest: /10.251.126.227:50010
+081110 224059 16244 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_5262186175243998904 terminating
+081110 224154 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.215.192:50010 is added to blk_-1704027189958470814 size 67108864
+081110 224209 16540 INFO dfs.DataNode$DataXceiver: Receiving block blk_-337665304078248571 src: /10.251.106.37:55462 dest: /10.251.106.37:50010
+081110 224212 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.106.50:50010 is added to blk_-2023442822091562967 size 67108864
+081110 224218 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.198.196:50010 is added to blk_1779145401405339993 size 28499417
+081110 224338 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.199.159:50010 is added to blk_7705518309270121951 size 67108864
+081110 224437 16512 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-9120005470237070778 terminating
+081110 224504 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.7.32:50010 is added to blk_3849239820458663566 size 67108864
+081110 224632 16607 INFO dfs.DataNode$DataXceiver: Receiving block blk_-1657856234642335063 src: /10.251.38.197:44516 dest: /10.251.38.197:50010
+081110 224636 16576 INFO dfs.DataNode$PacketResponder: Received block blk_6490003020931145707 of size 67108864 from /10.251.42.246
+081110 224637 16371 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_6048652012880073760 terminating
+081110 224652 16437 INFO dfs.DataNode$PacketResponder: Received block blk_5648034804629064273 of size 67108864 from /10.251.91.159
+081110 224732 16377 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_5912213716795619450 terminating
+081110 224746 16694 INFO dfs.DataNode$PacketResponder: Received block blk_-5534560875087182998 of size 67108864 from /10.250.7.230
+081110 224755 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt3/_temporary/_task_200811101024_0007_m_001560_0/part-01560. blk_3376391218693716925
+081110 224817 16597 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_2691304991047255190 terminating
+081110 224932 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt3/_temporary/_task_200811101024_0007_m_001230_0/part-01230. blk_8708862520108736953
+081110 224938 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.75.79:50010 is added to blk_-5718873743060788176 size 67108864
+081110 224958 16603 INFO dfs.DataNode$DataXceiver: Receiving block blk_-2989288139685694818 src: /10.250.19.227:60160 dest: /10.250.19.227:50010
+081110 225056 16728 INFO dfs.DataNode$DataXceiver: Receiving block blk_6245594177708848366 src: /10.250.15.198:46793 dest: /10.250.15.198:50010
+081110 225124 16591 INFO dfs.DataNode$PacketResponder: Received block blk_4433676399725693167 of size 67108864 from /10.251.37.240
+081110 225213 16632 INFO dfs.DataNode$PacketResponder: Received block blk_-5644397018622018109 of size 67108864 from /10.251.109.236
+081110 225305 16687 INFO dfs.DataNode$PacketResponder: Received block blk_-6986311820863339652 of size 67108864 from /10.251.71.240
+081110 225351 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.39.64:50010 is added to blk_207875475387433291 size 67108864
+081110 225400 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.199.225:50010 is added to blk_-7115635482536854135 size 67108864
+081110 225423 16747 INFO dfs.DataNode$PacketResponder: Received block blk_-1956140031907143783 of size 67108864 from /10.251.70.112
+081110 225642 16655 INFO dfs.DataNode$PacketResponder: Received block blk_7534378757788640871 of size 67108864 from /10.251.214.130
+081110 225740 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt3/_temporary/_task_200811101024_0007_m_001662_0/part-01662. blk_8196657927516481490
+081110 225813 16867 INFO dfs.DataNode$DataXceiver: Receiving block blk_-5029807829679779067 src: /10.251.122.79:49600 dest: /10.251.122.79:50010
+081110 225905 16532 INFO dfs.DataNode$DataXceiver: Receiving block blk_-3657751236932275338 src: /10.251.123.99:50481 dest: /10.251.123.99:50010
+081110 225947 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.74.227:50010 is added to blk_1594026090263820445 size 67108864
+081110 230105 13 INFO dfs.DataBlockScanner: Verification succeeded for blk_3894335463008345041
+081110 230202 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.193.224:50010 is added to blk_-6299730951392868297 size 67108864
+081110 230314 16898 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_157913239647511296 terminating
+081110 230315 16811 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-6454539193224916125 terminating
+081110 230338 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.194.213:50010 is added to blk_-3575568207121859434 size 67108864
+081110 230457 16876 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-4325209272072286951 terminating
+081110 230508 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.91.159:50010 is added to blk_-5739126205963920408 size 67108864
+081110 230524 16637 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-9056865861421808370 terminating
+081110 230536 16598 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-6934248664959947757 terminating
+081110 230545 16742 INFO dfs.DataNode$PacketResponder: Received block blk_-2082401934988378573 of size 67108864 from /10.251.214.112
+081110 230627 16366 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_7627900514276120558 terminating
+081110 230628 16721 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-1250775350296476256 terminating
+081110 230633 16678 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_2389216938154332862 terminating
+081110 230859 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.38.53:50010 is added to blk_7430820184211246929 size 67108864
+081110 231236 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-608202790716579401 is added to invalidSet of 10.251.198.33:50010
+081110 231241 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-1335063409877429524 is added to invalidSet of 10.251.107.196:50010
+081110 231556 16543 INFO dfs.DataNode$DataXceiver: 10.251.202.181:50010 Served block blk_-5236655516146555545 to /10.251.31.5
+081110 231904 17028 WARN dfs.DataNode$DataXceiver: 10.251.75.143:50010:Got exception while serving blk_2262752117989012641 to /10.250.13.188:
+081110 231911 16933 WARN dfs.DataNode$DataXceiver: 10.251.126.227:50010:Got exception while serving blk_-4181768899028058192 to /10.251.26.177:
+081110 232739 16715 INFO dfs.DataNode$DataXceiver: 10.251.123.99:50010 Served block blk_-7990763409688650846 to /10.251.197.161
+081110 233940 17094 INFO dfs.DataNode$DataXceiver: 10.250.17.225:50010 Served block blk_-2656323385657954732 to /10.250.17.225
+081110 233954 17191 WARN dfs.DataNode$DataXceiver: 10.250.7.230:50010:Got exception while serving blk_-7029628814943626474 to /10.251.38.197:
+081110 235445 16879 INFO dfs.DataNode$DataXceiver: 10.251.127.243:50010 Served block blk_8711213005689112399 to /10.251.74.134
+081111 000037 17163 INFO dfs.DataNode$DataXceiver: 10.251.195.70:50010 Served block blk_-3696162841836791939 to /10.251.195.70
+081111 000626 17362 INFO dfs.DataNode$DataXceiver: 10.251.91.84:50010 Served block blk_-8915491531889006304 to /10.251.91.84
+081111 000932 16928 INFO dfs.DataNode$DataXceiver: 10.251.90.64:50010 Served block blk_-657087263710195616 to /10.250.14.196
+081111 002741 17343 INFO dfs.DataNode$DataXceiver: 10.250.10.213:50010 Served block blk_-1125621902344947014 to /10.250.10.213
+081111 004102 17259 WARN dfs.DataNode$DataXceiver: 10.251.214.175:50010:Got exception while serving blk_481857539063371482 to /10.251.105.189:
+081111 004657 17337 INFO dfs.DataNode$DataXceiver: 10.250.10.6:50010 Served block blk_1200136320542454615 to /10.250.10.6
+081111 011254 17716 WARN dfs.DataNode$DataXceiver: 10.251.39.144:50010:Got exception while serving blk_-8083036675630459841 to /10.251.39.209:
+081111 012254 17517 WARN dfs.DataNode$DataXceiver: 10.250.7.32:50010:Got exception while serving blk_-1508527605812345693 to /10.251.74.192:
+081111 013241 17501 INFO dfs.DataNode$DataXceiver: 10.251.31.180:50010 Served block blk_3905759687686730625 to /10.251.31.180
+081111 013322 17524 INFO dfs.DataNode$DataXceiver: 10.251.121.224:50010 Served block blk_342378162324355732 to /10.251.121.224
+081111 013400 17543 INFO dfs.DataNode$DataXceiver: 10.250.14.38:50010 Served block blk_-8674089929114017279 to /10.250.14.38
+081111 014431 17416 WARN dfs.DataNode$DataXceiver: 10.251.107.98:50010:Got exception while serving blk_-3140031507252212554 to /10.250.7.244:
+081111 020752 17598 INFO dfs.DataNode$DataXceiver: 10.251.125.237:50010 Served block blk_-309134958179110212 to /10.251.125.237
+081111 022143 17663 INFO dfs.DataNode$DataXceiver: 10.250.13.240:50010 Served block blk_-3134225108208373949 to /10.250.13.240
+081111 023010 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-8887373200836701910 is added to invalidSet of 10.251.193.224:50010
+081111 023011 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-1162676743264290624 is added to invalidSet of 10.251.194.213:50010
+081111 023011 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-5513640508500780385 is added to invalidSet of 10.251.203.179:50010
+081111 023011 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-7767902948513849386 is added to invalidSet of 10.251.71.146:50010
+081111 023013 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-5382946262718129284 is added to invalidSet of 10.250.5.161:50010
+081111 023013 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_5668137923110942035 is added to invalidSet of 10.251.91.229:50010
+081111 023013 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_7197514030988119866 is added to invalidSet of 10.251.75.49:50010
+081111 023015 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-5362598472846558076 is added to invalidSet of 10.250.14.143:50010
+081111 023017 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-4269939382058952254 is added to invalidSet of 10.251.203.129:50010
+081111 023017 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-6978845808078082463 is added to invalidSet of 10.251.109.209:50010
+081111 023022 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-1071115021179995772 is added to invalidSet of 10.250.11.53:50010
+081111 023022 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_7336636250384047238 is added to invalidSet of 10.251.26.177:50010
+081111 023022 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_8493856762887493521 is added to invalidSet of 10.251.26.131:50010
+081111 023024 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_1043487525777829194 is added to invalidSet of 10.251.110.8:50010
+081111 023024 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-3225035678192156905 is added to invalidSet of 10.251.38.214:50010
+081111 023025 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_5572208681898881669 is added to invalidSet of 10.251.38.197:50010
+081111 023027 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-2225353020301959077 is added to invalidSet of 10.251.125.237:50010
+081111 023027 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_3946183108430554053 is added to invalidSet of 10.250.11.100:50010
+081111 023033 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-3681974396824196300 is added to invalidSet of 10.250.17.177:50010
+081111 023037 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_2736251498135196075 is added to invalidSet of 10.251.90.64:50010
+081111 023039 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_1275198635723397883 is added to invalidSet of 10.251.202.134:50010
+081111 023039 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_3428998332517532825 is added to invalidSet of 10.251.43.192:50010
+081111 023139 19 INFO dfs.FSDataset: Deleting block blk_-7106479503467535906 file /mnt/hadoop/dfs/data/current/subdir32/blk_-7106479503467535906
+081111 023149 19 INFO dfs.FSDataset: Deleting block blk_-7411858598798393933 file /mnt/hadoop/dfs/data/current/subdir24/blk_-7411858598798393933
+081111 023156 19 INFO dfs.FSDataset: Deleting block blk_-5429479049793046826 file /mnt/hadoop/dfs/data/current/subdir34/blk_-5429479049793046826
+081111 023158 19 INFO dfs.FSDataset: Deleting block blk_-6431101765137189231 file /mnt/hadoop/dfs/data/current/subdir33/blk_-6431101765137189231
+081111 023216 19 INFO dfs.FSDataset: Deleting block blk_-2923662094689783995 file /mnt/hadoop/dfs/data/current/subdir38/blk_-2923662094689783995
+081111 023222 17683 INFO dfs.DataNode$DataXceiver: 10.250.14.143:50010 Served block blk_-664656559337730574 to /10.250.7.96
+081111 023222 17788 INFO dfs.DataNode$PacketResponder: Received block blk_3224393364314749254 of size 67108864 from /10.251.37.240
+081111 023229 19 INFO dfs.FSDataset: Deleting block blk_1483582953997932733 file /mnt/hadoop/dfs/data/current/subdir7/blk_1483582953997932733
+081111 023230 19 INFO dfs.FSDataset: Deleting block blk_-3607708283707030582 file /mnt/hadoop/dfs/data/current/subdir31/blk_-3607708283707030582
+081111 023234 19 INFO dfs.FSDataset: Deleting block blk_4365203784873840210 file /mnt/hadoop/dfs/data/current/subdir1/blk_4365203784873840210
+081111 023243 19 INFO dfs.FSDataset: Deleting block blk_1920931690498309324 file /mnt/hadoop/dfs/data/current/subdir42/blk_1920931690498309324
+081111 023243 19 INFO dfs.FSDataset: Deleting block blk_2731746367139956284 file /mnt/hadoop/dfs/data/current/subdir15/blk_2731746367139956284
+081111 023247 19 INFO dfs.FSDataset: Deleting block blk_3312198496468502316 file /mnt/hadoop/dfs/data/current/subdir36/blk_3312198496468502316
+081111 023247 19 INFO dfs.FSDataset: Deleting block blk_-626413149556394155 file /mnt/hadoop/dfs/data/current/subdir26/blk_-626413149556394155
+081111 023248 18 INFO dfs.FSDataset: Deleting block blk_1350741653957819140 file /mnt/hadoop/dfs/data/current/subdir32/blk_1350741653957819140
+081111 023248 19 INFO dfs.FSDataset: Deleting block blk_6675564098604634452 file /mnt/hadoop/dfs/data/current/subdir1/blk_6675564098604634452
+081111 023249 19 INFO dfs.FSDataset: Deleting block blk_1692958087244489888 file /mnt/hadoop/dfs/data/current/subdir62/blk_1692958087244489888
+081111 023250 18 INFO dfs.FSDataset: Deleting block blk_5528471097481810388 file /mnt/hadoop/dfs/data/current/subdir5/blk_5528471097481810388
+081111 023250 19 INFO dfs.FSDataset: Deleting block blk_797263375273454863 file /mnt/hadoop/dfs/data/current/subdir16/blk_797263375273454863
+081111 023255 19 INFO dfs.FSDataset: Deleting block blk_5209577451013188921 file /mnt/hadoop/dfs/data/current/subdir24/blk_5209577451013188921
+081111 023304 18 INFO dfs.FSDataset: Deleting block blk_4713539908695785630 file /mnt/hadoop/dfs/data/current/subdir39/blk_4713539908695785630
+081111 023310 19 INFO dfs.FSDataset: Deleting block blk_6148201552996212693 file /mnt/hadoop/dfs/data/current/subdir15/blk_6148201552996212693
+081111 023328 19 INFO dfs.FSDataset: Deleting block blk_9014154925388243050 file /mnt/hadoop/dfs/data/current/subdir28/blk_9014154925388243050
+081111 023330 19 INFO dfs.FSDataset: Deleting block blk_8761138012128091849 file /mnt/hadoop/dfs/data/current/subdir33/blk_8761138012128091849
+081111 023749 17857 INFO dfs.DataNode$PacketResponder: Received block blk_-4071286774767564790 of size 67108864 from /10.251.197.226
+081111 023914 17773 INFO dfs.DataNode$DataXceiver: 10.251.122.65:50010 Served block blk_2866275036574950116 to /10.250.11.53
+081111 024105 17911 INFO dfs.DataNode$PacketResponder: Received block blk_-6811519872198278365 of size 67108864 from /10.250.6.4
+081111 024133 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.199.19:50010 is added to blk_6748710057489679257 size 67108864
+081111 024247 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.39.209:50010 is added to blk_1833093108290599780 size 67108864
+081111 024304 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.7.146:50010 is added to blk_9163807899833139121 size 67108864
+081111 024309 17772 INFO dfs.DataNode$DataXceiver: Receiving block blk_3941798034503185737 src: /10.250.11.85:42358 dest: /10.250.11.85:50010
+081111 024325 17904 INFO dfs.DataNode$PacketResponder: Received block blk_6894918622505820383 of size 67108864 from /10.250.14.143
+081111 024443 17867 INFO dfs.DataNode$DataXceiver: Receiving block blk_6491424745418112176 src: /10.251.214.130:57008 dest: /10.251.214.130:50010
+081111 024443 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand4/_temporary/_task_200811101024_0009_m_000115_0/part-00115. blk_-17685631368401548
+081111 024724 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand4/_temporary/_task_200811101024_0009_m_000176_0/part-00176. blk_8924207394547472950
+081111 024742 17976 INFO dfs.DataNode$DataXceiver: Receiving block blk_-4526931594457272384 src: /10.251.43.147:40348 dest: /10.251.43.147:50010
+081111 024831 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.31.242:50010 is added to blk_5390763359901143305 size 67108864
+081111 024901 18086 INFO dfs.DataNode$DataXceiver: Receiving block blk_-11867600358649678 src: /10.251.75.79:46421 dest: /10.251.75.79:50010
+081111 024901 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.11.194:50010 is added to blk_2430417102497887445 size 67108864
+081111 024901 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.214.18:50010 is added to blk_-747046374856916711 size 67108864
+081111 025101 18187 INFO dfs.DataNode$PacketResponder: Received block blk_5062112794659861146 of size 67108864 from /10.251.91.84
+081111 025208 18218 INFO dfs.DataNode$DataXceiver: Receiving block blk_-116589515245909549 src: /10.251.203.179:33198 dest: /10.251.203.179:50010
+081111 025335 17997 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_4628975089896927394 terminating
+081111 025336 18090 INFO dfs.DataNode$DataXceiver: Receiving block blk_-764747190320632607 src: /10.251.127.191:49914 dest: /10.251.127.191:50010
+081111 025346 18124 INFO dfs.DataNode$PacketResponder: Received block blk_-8015797075596093783 of size 67108864 from /10.250.11.194
+081111 025424 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.110.160:50010 is added to blk_-1675768179383804109 size 67108864
+081111 025607 18122 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_1155029843511109085 terminating
+081111 025619 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.67.113:50010 is added to blk_9060964400089016309 size 67108864
+081111 025634 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.214.67:50010 is added to blk_-1417908110808566576 size 67108864
+081111 025653 18457 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-7483426835701512490 terminating
+081111 025732 18087 INFO dfs.DataNode$DataXceiver: Receiving block blk_-3752135158991310104 src: /10.251.70.5:44375 dest: /10.251.70.5:50010
+081111 025811 18303 INFO dfs.DataNode$DataXceiver: Receiving block blk_-8649503431827393598 src: /10.251.199.19:48778 dest: /10.251.199.19:50010
+081111 025903 18116 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-6883339133893273874 terminating
+081111 025915 18170 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_3695169334833427187 terminating
+081111 025945 18127 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_6055109613223910610 terminating
+081111 030015 18180 INFO dfs.DataNode$DataXceiver: Receiving block blk_-1868325377308234190 src: /10.251.42.207:50666 dest: /10.251.42.207:50010
+081111 030017 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.26.177:50010 is added to blk_-6338549285508312302 size 3530010
+081111 030051 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.30.179:50010 is added to blk_-900758580041645081 size 3543900
+081111 030153 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.66.3:50010 is added to blk_1756478622414930264 size 67108864
+081111 030225 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.127.47:50010 is added to blk_-6555060221133060529 size 67108864
+081111 030233 18516 INFO dfs.DataNode$DataXceiver: Receiving block blk_9076677650086747187 src: /10.251.35.1:52094 dest: /10.251.35.1:50010
+081111 030236 18183 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-4165562468976768862 terminating
+081111 030240 18460 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-3295982945091621137 terminating
+081111 030300 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.15.240:50010 is added to blk_-7637577152926063076 size 67108864
+081111 030318 18190 INFO dfs.DataNode$DataXceiver: Receiving block blk_3181161977343808286 src: /10.251.43.21:40127 dest: /10.251.43.21:50010
+081111 030414 18143 INFO dfs.DataNode$DataXceiver: Receiving block blk_6807535563873595117 src: /10.250.17.177:48934 dest: /10.250.17.177:50010
+081111 030416 18548 INFO dfs.DataNode$DataXceiver: Receiving block blk_7513976340045981966 src: /10.251.42.207:36468 dest: /10.251.42.207:50010
+081111 030418 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand4/_temporary/_task_200811101024_0009_m_001061_0/part-01061. blk_-749176535135404637
+081111 030501 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.199.245:50010 is added to blk_-7909610753867924116 size 67108864
+081111 030726 18409 INFO dfs.DataNode$PacketResponder: Received block blk_-7247291679155656679 of size 67108864 from /10.250.10.176
+081111 030736 18126 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-6369730481066968769 terminating
+081111 030745 18290 INFO dfs.DataNode$DataXceiver: Receiving block blk_7780461223860192433 src: /10.251.127.191:58148 dest: /10.251.127.191:50010
+081111 030942 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand4/_temporary/_task_200811101024_0009_m_001281_0/part-01281. blk_2084123600915946046
+081111 030946 18336 INFO dfs.DataNode$DataXceiver: Receiving block blk_92273823183917102 src: /10.250.15.67:53441 dest: /10.250.15.67:50010
+081111 030950 18479 INFO dfs.DataNode$PacketResponder: Received block blk_-1141332313413855099 of size 67108864 from /10.251.89.155
+081111 030958 18454 INFO dfs.DataNode$DataXceiver: Receiving block blk_3016571528120363023 src: /10.251.194.102:60235 dest: /10.251.194.102:50010
+081111 031106 18346 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7678242108759603056 src: /10.251.125.193:33553 dest: /10.251.125.193:50010
+081111 031143 18339 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7526023914950151999 src: /10.250.5.161:48457 dest: /10.250.5.161:50010
+081111 031257 18567 INFO dfs.DataNode$DataXceiver: Receiving block blk_-6380328072112550668 src: /10.250.6.191:37701 dest: /10.250.6.191:50010
+081111 031258 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.11.100:50010 is added to blk_3222673463853349950 size 67108864
+081111 031307 18432 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-3183355402229300197 terminating
+081111 031334 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.26.8:50010 is added to blk_-5963475042722370536 size 67108864
+081111 031436 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand4/_temporary/_task_200811101024_0009_m_001398_0/part-01398. blk_-7527506469734664572
+081111 031541 18484 INFO dfs.DataNode$PacketResponder: Received block blk_9072486569292195232 of size 67108864 from /10.251.71.68
+081111 031621 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.199.159:50010 is added to blk_-4455205822455130625 size 67108864
+081111 031650 18225 INFO dfs.DataNode$PacketResponder: Received block blk_3777399812922072863 of size 67108864 from /10.251.199.225
+081111 031730 18310 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-4633546693082073737 terminating
+081111 031735 18435 INFO dfs.DataNode$PacketResponder: Received block blk_6799391641508508235 of size 67108864 from /10.251.107.98
+081111 031811 18619 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_1002945451269828722 terminating
+081111 031900 18547 INFO dfs.DataNode$PacketResponder: Received block blk_566413670355737377 of size 67108864 from /10.251.122.79
+081111 031938 16978 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_2819581679409796253 terminating
+081111 031951 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.127.243:50010 is added to blk_1512923509505250283 size 67108864
+081111 032053 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand4/_temporary/_task_200811101024_0009_m_001611_0/part-01611. blk_285336326661214154
+081111 032121 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.90.134:50010 is added to blk_5955377624764578810 size 67108864
+081111 032357 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand4/_temporary/_task_200811101024_0009_m_001574_0/part-01574. blk_-7458279618877678162
+081111 032416 18576 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_5018765878120211503 terminating
+081111 032531 18607 INFO dfs.DataNode$DataXceiver: Receiving block blk_313888672758374538 src: /10.251.39.179:40031 dest: /10.251.39.179:50010
+081111 032544 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.109.209:50010 is added to blk_3764801892187716497 size 67108864
+081111 032612 18586 INFO dfs.DataNode$PacketResponder: Received block blk_-3491385689517593364 of size 67108864 from /10.251.193.224
+081111 032655 18710 INFO dfs.DataNode$PacketResponder: Received block blk_-2243784245784480521 of size 67108864 from /10.250.6.191
+081111 032813 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.6.223:50010 is added to blk_-4052810234606327693 size 67108864
+081111 032825 18758 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-6695620358347030339 terminating
+081111 032828 18581 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-5102453487463005287 terminating
+081111 032900 18814 INFO dfs.DataNode$DataXceiver: Receiving block blk_7924393760966842810 src: /10.251.202.209:59148 dest: /10.251.202.209:50010
+081111 032917 18710 INFO dfs.DataNode$PacketResponder: Received block blk_5915244038969911075 of size 67108864 from /10.250.11.53
+081111 033110 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.10.144:50010 is added to blk_3243316191092266549 size 67108864
+081111 033125 18859 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_8229768485681546149 terminating
+081111 033211 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.43.21:50010 is added to blk_3206064173813164493 size 67108864
+081111 033426 18894 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-1957299792594627113 terminating
+081111 033444 18940 INFO dfs.DataNode$DataXceiver: Receiving block blk_-1690784932539647416 src: /10.251.31.180:50205 dest: /10.251.31.180:50010
+081111 033505 18847 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_6745520736924802462 terminating
+081111 033819 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-1525964299678787959 is added to invalidSet of 10.251.37.240:50010
+081111 033823 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_7045475543362904558 is added to invalidSet of 10.251.106.214:50010
+081111 033824 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-6802124772693111025 is added to invalidSet of 10.251.66.63:50010
+081111 033829 18 INFO dfs.FSDataset: Deleting block blk_-5205950257901523262 file /mnt/hadoop/dfs/data/current/subdir40/blk_-5205950257901523262
+081111 033925 18906 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-1649239999940418046 terminating
+081111 033927 19172 INFO dfs.DataNode$PacketResponder: Received block blk_6880728743505526406 of size 67108864 from /10.251.197.226
+081111 033935 18945 INFO dfs.DataNode$DataXceiver: Receiving block blk_5256716488526744434 src: /10.251.73.220:42064 dest: /10.251.73.220:50010
+081111 033953 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.26.177:50010 is added to blk_6928449948805597176 size 67108864
+081111 034105 18847 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_2529569087635823495 terminating
+081111 034252 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt4/_temporary/_task_200811101024_0010_m_000222_0/part-00222. blk_3764836840384130740
+081111 034323 19025 INFO dfs.DataNode$DataXceiver: Receiving block blk_3020717811556957482 src: /10.251.90.81:48077 dest: /10.251.90.81:50010
+081111 034351 18690 INFO dfs.DataNode$PacketResponder: Received block blk_-577659324269246113 of size 67108864 from /10.251.203.179
+081111 034456 18909 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_6137960563260046065 terminating
+081111 034600 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.203.246:50010 is added to blk_-6909400912794057067 size 67108864
+081111 034712 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.43.192:50010 is added to blk_8249475180346179102 size 67108864
+081111 034726 19054 INFO dfs.DataNode$PacketResponder: Received block blk_-5045144756510626150 of size 67108864 from /10.251.39.160
+081111 034742 19142 INFO dfs.DataNode$PacketResponder: Received block blk_752365829198406123 of size 67108864 from /10.250.6.214
+081111 034937 19166 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_5663417083925711869 terminating
+081111 034945 19257 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-2014243777892518956 terminating
+081111 035010 19149 INFO dfs.DataNode$DataXceiver: Receiving block blk_-8123824094195108685 src: /10.251.194.213:54308 dest: /10.251.194.213:50010
+081111 035113 19229 INFO dfs.DataNode$DataXceiver: Receiving block blk_2080318574920472813 src: /10.251.39.64:40530 dest: /10.251.39.64:50010
+081111 035115 18830 INFO dfs.DataNode$PacketResponder: Received block blk_-290874442865281380 of size 28497700 from /10.251.203.179
+081111 035152 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.73.220:50010 is added to blk_5953577136151423920 size 67108864
+081111 035247 19144 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-2780312306380730204 terminating
+081111 035417 19387 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-633826175832239328 terminating
+081111 035532 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.15.101:50010 is added to blk_-6540455811923725840 size 67108864
+081111 035620 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.123.1:50010 is added to blk_6308888821787547357 size 67108864
+081111 035834 19205 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_4638603954320058978 terminating
+081111 035913 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.91.229:50010 is added to blk_-4651707530079874243 size 67108864
+081111 035915 19117 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_5115892145206906855 terminating
+081111 035948 19511 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-2421414377433740760 terminating
+081111 035957 19217 INFO dfs.DataNode$PacketResponder: Received block blk_-420564586555502239 of size 67108864 from /10.251.90.64
+081111 040107 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt4/_temporary/_task_200811101024_0010_m_000881_0/part-00881. blk_-3091906986951252347
+081111 040246 19412 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-4068751061953213467 terminating
+081111 040251 19350 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-3025440686907267472 terminating
+081111 040402 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.215.70:50010 is added to blk_-420818767915591010 size 67108864
+081111 040405 19541 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_8422946850755720617 terminating
+081111 040425 19408 INFO dfs.DataNode$DataXceiver: Receiving block blk_-5646228903161999640 src: /10.251.71.97:60870 dest: /10.251.71.97:50010
+081111 040521 19253 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-7024895786822269814 terminating
+081111 040537 19518 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-4430291708660291878 terminating
+081111 040543 19431 INFO dfs.DataNode$DataXceiver: Receiving block blk_-6250368566161066085 src: /10.251.31.180:42992 dest: /10.251.31.180:50010
+081111 040544 19362 INFO dfs.DataNode$DataXceiver: Receiving block blk_-6213380972217661202 src: /10.251.203.149:40478 dest: /10.251.203.149:50010
+081111 040604 19555 INFO dfs.DataNode$PacketResponder: Received block blk_3813891701916249413 of size 67108864 from /10.251.121.224
+081111 040626 19526 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_903961454948542202 terminating
+081111 040653 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.42.16:50010 is added to blk_3954386352306480748 size 67108864
+081111 040658 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.105.189:50010 is added to blk_4812792845864526586 size 67108864
+081111 040728 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.70.211:50010 is added to blk_5570475465835003801 size 67108864
+081111 040751 19585 INFO dfs.DataNode$PacketResponder: Received block blk_-9190864897806028230 of size 67108864 from /10.251.214.130
+081111 040754 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.31.242:50010 is added to blk_-4342304152206614489 size 67108864
+081111 040857 19185 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-190773840747023361 terminating
+081111 041004 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.71.240:50010 is added to blk_-5580048401594934039 size 67108864
+081111 041039 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.39.242:50010 is added to blk_6640583412927022083 size 67108864
+081111 041111 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.65.203:50010 is added to blk_-1332315107905285608 size 67108864
+081111 041218 19235 INFO dfs.DataNode$PacketResponder: Received block blk_3550669278239526374 of size 67108864 from /10.251.123.1
+081111 041219 19820 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_4873550540813847659 terminating
+081111 041252 19248 INFO dfs.DataNode$DataXceiver: Receiving block blk_-1133573997287815203 src: /10.251.123.195:59430 dest: /10.251.123.195:50010
+081111 041349 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.74.134:50010 is added to blk_2740792916077430444 size 28482383
+081111 041425 19630 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_2851869865185325732 terminating
+081111 041443 19498 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-1842096107468319932 terminating
+081111 041509 20066 INFO dfs.DataNode$PacketResponder: Received block blk_-8965508153794244104 of size 28494398 from /10.251.70.112
+081111 041532 19592 INFO dfs.DataNode$DataXceiver: Receiving block blk_1074754942323612586 src: /10.251.202.181:45279 dest: /10.251.202.181:50010
+081111 041534 19842 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7727864185516010230 src: /10.251.43.192:36039 dest: /10.251.43.192:50010
+081111 041701 19403 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-4779205255695723216 terminating
+081111 041734 19799 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_2261089810991980611 terminating
+081111 041811 19543 INFO dfs.DataNode$DataXceiver: Receiving block blk_5335498635665743905 src: /10.251.73.220:50095 dest: /10.251.73.220:50010
+081111 041926 19700 INFO dfs.DataNode$DataXceiver: Receiving block blk_-5144503768267321004 src: /10.251.107.19:36862 dest: /10.251.107.19:50010
+081111 042009 19800 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_1927336911952959118 terminating
+081111 042024 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.203.166:50010 is added to blk_-2332150303475653460 size 67108864
+081111 042042 19757 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_2111886617384066018 terminating
+081111 042100 19804 INFO dfs.DataNode$DataXceiver: Receiving block blk_-2506231977021079951 src: /10.251.31.160:57634 dest: /10.251.31.160:50010
+081111 042129 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.199.86:50010 is added to blk_4330492872922862223 size 67108864
+081111 042353 19811 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_6918427074195439966 terminating
+081111 042416 19265 INFO dfs.DataNode$DataXceiver: Receiving block blk_4284688617983009262 src: /10.251.91.32:57548 dest: /10.251.91.32:50010
+081111 042427 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.31.5:50010 is added to blk_5813361416484537967 size 67108864
+081111 042456 19952 INFO dfs.DataNode$DataXceiver: Receiving block blk_-2313277713021896570 src: /10.251.123.195:58823 dest: /10.251.123.195:50010
+081111 042457 19726 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-7778922135767840250 terminating
+081111 042625 19958 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7350482598011027441 src: /10.250.7.96:41476 dest: /10.250.7.96:50010
+081111 042735 19901 INFO dfs.DataNode$PacketResponder: Received block blk_-3607860197409267245 of size 28503188 from /10.251.31.180
+081111 042824 18264 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_4178945095089206682 terminating
+081111 043015 19875 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-3363550789841756902 terminating
+081111 043042 20058 INFO dfs.DataNode$DataXceiver: Receiving block blk_345577139488306634 src: /10.251.37.240:38873 dest: /10.251.37.240:50010
+081111 043106 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.71.193:50010 is added to blk_4577632468651859430 size 67108864
+081111 043132 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt4/_temporary/_task_200811101024_0010_m_001716_0/part-01716. blk_-2051219911597308805
+081111 043140 19599 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-2680500627064966252 terminating
+081111 043222 20077 INFO dfs.DataNode$DataXceiver: Receiving block blk_-9092685890953655332 src: /10.250.15.240:43274 dest: /10.250.15.240:50010
+081111 043341 19898 INFO dfs.DataNode$DataXceiver: Receiving block blk_-4473020641607592551 src: /10.251.42.191:48114 dest: /10.251.42.191:50010
+081111 043358 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.111.37:50010 is added to blk_-524128780228307052 size 67108864
+081111 043515 20251 INFO dfs.DataNode$PacketResponder: Received block blk_4443043493758564822 of size 67108864 from /10.251.106.37
+081111 043630 20253 INFO dfs.DataNode$PacketResponder: Received block blk_5118390778403008591 of size 67108864 from /10.251.30.101
+081111 043746 20226 INFO dfs.DataNode$DataXceiver: Receiving block blk_2737505352081488746 src: /10.251.194.245:52516 dest: /10.251.194.245:50010
+081111 043825 20130 INFO dfs.DataNode$PacketResponder: Received block blk_-9013487557842539661 of size 28485342 from /10.251.215.192
+081111 043903 20003 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-8638442557570632582 terminating
+081111 044041 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.202.209:50010 is added to blk_111759050707136656 size 67108864
+081111 044304 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_2259206517962925438 is added to invalidSet of 10.251.215.16:50010
+081111 044304 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-3854777877236596649 is added to invalidSet of 10.251.39.160:50010
+081111 044305 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-4265150363959543078 is added to invalidSet of 10.251.39.160:50010
+081111 044309 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_3729730843466061623 is added to invalidSet of 10.251.27.63:50010
+081111 044310 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_3876184938151091897 is added to invalidSet of 10.251.30.85:50010
+081111 044311 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-1227720343537039835 is added to invalidSet of 10.251.202.134:50010
+081111 044314 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-6921441628286995043 is added to invalidSet of 10.251.126.83:50010
+081111 044315 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_3539852484771802299 is added to invalidSet of 10.250.19.227:50010
+081111 044316 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_2341651676737321162 is added to invalidSet of 10.251.203.129:50010
+081111 044318 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-765820154946060546 is added to invalidSet of 10.251.65.203:50010
+081111 044319 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-2492400942012223395 is added to invalidSet of 10.251.202.209:50010
+081111 044320 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-8351015090014570293 is added to invalidSet of 10.251.199.86:50010
+081111 044328 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-328970571549408286 is added to invalidSet of 10.251.214.32:50010
+081111 044328 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-8130925109202184099 is added to invalidSet of 10.251.125.193:50010
+081111 044331 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-3242342105286997235 is added to invalidSet of 10.251.71.97:50010
+081111 044332 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_2468407162668753567 is added to invalidSet of 10.251.106.37:50010
+081111 044335 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_7841365850685201915 is added to invalidSet of 10.251.110.68:50010
+081111 044337 13 INFO dfs.DataBlockScanner: Verification succeeded for blk_-6160667975382232149
+081111 044338 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_2426255659473300323 is added to invalidSet of 10.251.106.37:50010
+081111 044338 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_5203504995927133832 is added to invalidSet of 10.250.13.240:50010
+081111 044340 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_815809455641029563 is added to invalidSet of 10.251.111.37:50010
+081111 044343 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_6413710007211667486 is added to invalidSet of 10.251.30.179:50010
+081111 044345 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-2907776069874917892 is added to invalidSet of 10.251.215.16:50010
+081111 044347 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-5802915611610989626 is added to invalidSet of 10.251.110.196:50010
+081111 044349 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-7668075074035173978 is added to invalidSet of 10.251.31.5:50010
+081111 044351 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-1573544581830458089 is added to invalidSet of 10.251.122.65:50010
+081111 044353 19 INFO dfs.FSDataset: Deleting block blk_-1180596628202464893 file /mnt/hadoop/dfs/data/current/subdir52/blk_-1180596628202464893
+081111 044427 20289 INFO dfs.DataNode$DataXceiver: Receiving block blk_1407935810673971357 src: /10.251.123.99:54184 dest: /10.251.123.99:50010
+081111 044522 18 INFO dfs.FSDataset: Deleting block blk_-8167717961644709843 file /mnt/hadoop/dfs/data/current/blk_-8167717961644709843
+081111 044543 19 INFO dfs.FSDataset: Deleting block blk_-7464161062429228045 file /mnt/hadoop/dfs/data/current/subdir19/blk_-7464161062429228045
+081111 044546 19 INFO dfs.FSDataset: Deleting block blk_-5934436507161953485 file /mnt/hadoop/dfs/data/current/subdir33/blk_-5934436507161953485
+081111 044546 20347 INFO dfs.DataNode$PacketResponder: Received block blk_-3922743468150895472 of size 67108864 from /10.251.39.179
+081111 044550 19 INFO dfs.FSDataset: Deleting block blk_-7832937837605180330 file /mnt/hadoop/dfs/data/current/subdir49/blk_-7832937837605180330
+081111 044554 19 INFO dfs.FSDataset: Deleting block blk_-8547071368131084410 file /mnt/hadoop/dfs/data/current/subdir38/blk_-8547071368131084410
+081111 044556 19 INFO dfs.FSDataset: Deleting block blk_-5429042599096020592 file /mnt/hadoop/dfs/data/current/subdir34/blk_-5429042599096020592
+081111 044612 19 INFO dfs.FSDataset: Deleting block blk_-6350492516478706425 file /mnt/hadoop/dfs/data/current/subdir36/blk_-6350492516478706425
+081111 044624 19 INFO dfs.FSDataset: Deleting block blk_-6053005391233809507 file /mnt/hadoop/dfs/data/current/subdir27/blk_-6053005391233809507
+081111 044624 20167 INFO dfs.DataNode$PacketResponder: Received block blk_-1522998827901549925 of size 67108864 from /10.251.127.47
+081111 044630 19 INFO dfs.FSDataset: Deleting block blk_-4311652947826112510 file /mnt/hadoop/dfs/data/current/subdir57/blk_-4311652947826112510
+081111 044635 19 INFO dfs.FSDataset: Deleting block blk_-1754204887541031211 file /mnt/hadoop/dfs/data/current/subdir58/blk_-1754204887541031211
+081111 044639 19 INFO dfs.FSDataset: Deleting block blk_-4165176068096983220 file /mnt/hadoop/dfs/data/current/subdir34/blk_-4165176068096983220
+081111 044648 19 INFO dfs.FSDataset: Deleting block blk_4863571548336254624 file /mnt/hadoop/dfs/data/current/subdir5/blk_4863571548336254624
+081111 044650 19 INFO dfs.FSDataset: Deleting block blk_-4844505495441326897 file /mnt/hadoop/dfs/data/current/subdir36/blk_-4844505495441326897
+081111 044652 19 INFO dfs.FSDataset: Deleting block blk_-7513928662244669476 file /mnt/hadoop/dfs/data/current/subdir11/blk_-7513928662244669476
+081111 044654 19 INFO dfs.FSDataset: Deleting block blk_-5014786445735476734 file /mnt/hadoop/dfs/data/current/subdir9/blk_-5014786445735476734
+081111 044700 19 INFO dfs.FSDataset: Deleting block blk_-1046472716157313227 file /mnt/hadoop/dfs/data/current/subdir62/blk_-1046472716157313227
+081111 044700 19 INFO dfs.FSDataset: Deleting block blk_-1281276222788579863 file /mnt/hadoop/dfs/data/current/subdir30/blk_-1281276222788579863
+081111 044704 19 INFO dfs.FSDataset: Deleting block blk_449049393237281194 file /mnt/hadoop/dfs/data/current/subdir18/blk_449049393237281194
+081111 044716 19 INFO dfs.FSDataset: Deleting block blk_352185875883785141 file /mnt/hadoop/dfs/data/current/subdir44/blk_352185875883785141
+081111 044720 19 INFO dfs.FSDataset: Deleting block blk_-2890295200276774269 file /mnt/hadoop/dfs/data/current/subdir29/blk_-2890295200276774269
+081111 044728 18 INFO dfs.FSDataset: Deleting block blk_1379455396847512711 file /mnt/hadoop/dfs/data/current/blk_1379455396847512711
+081111 044740 19 INFO dfs.FSDataset: Deleting block blk_2180875151184358991 file /mnt/hadoop/dfs/data/current/subdir31/blk_2180875151184358991
+081111 044749 19766 INFO dfs.DataNode$DataXceiver: Receiving block blk_-8879979113392880065 src: /10.251.202.181:33345 dest: /10.251.202.181:50010
+081111 044752 19 INFO dfs.FSDataset: Deleting block blk_1553688227908800900 file /mnt/hadoop/dfs/data/current/subdir15/blk_1553688227908800900
+081111 044757 19 INFO dfs.FSDataset: Deleting block blk_6138894560185644209 file /mnt/hadoop/dfs/data/current/subdir42/blk_6138894560185644209
+081111 044759 19 INFO dfs.FSDataset: Deleting block blk_-1368324087589035770 file /mnt/hadoop/dfs/data/current/blk_-1368324087589035770
+081111 044759 19 INFO dfs.FSDataset: Deleting block blk_3274968259628929519 file /mnt/hadoop/dfs/data/current/subdir19/blk_3274968259628929519
+081111 044806 19 INFO dfs.FSDataset: Deleting block blk_5736622945587812309 file /mnt/hadoop/dfs/data/current/subdir19/blk_5736622945587812309
+081111 044812 19 INFO dfs.FSDataset: Deleting block blk_9142114171015520823 file /mnt/hadoop/dfs/data/current/subdir48/blk_9142114171015520823
+081111 044822 19 INFO dfs.FSDataset: Deleting block blk_8556592730481313831 file /mnt/hadoop/dfs/data/current/blk_8556592730481313831
+081111 044834 19 INFO dfs.FSDataset: Deleting block blk_6147898566868510104 file /mnt/hadoop/dfs/data/current/subdir36/blk_6147898566868510104
+081111 044847 20391 INFO dfs.DataNode$DataXceiver: Receiving block blk_-4334868513923498900 src: /10.251.91.15:35440 dest: /10.251.91.15:50010
+081111 044855 19 INFO dfs.FSDataset: Deleting block blk_9081834782322008396 file /mnt/hadoop/dfs/data/current/subdir40/blk_9081834782322008396
+081111 044913 18 INFO dfs.FSDataset: Deleting block blk_8962411947457130719 file /mnt/hadoop/dfs/data/current/subdir16/blk_8962411947457130719
+081111 045125 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.75.143:50010 is added to blk_2312679955495839894 size 67108864
+081111 045125 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.75.143:50010 is added to blk_7434237665308221519 size 67108864
+081111 045222 20321 INFO dfs.DataNode$DataXceiver: Receiving block blk_2380775154966815858 src: /10.251.107.50:33333 dest: /10.251.107.50:50010
+081111 045224 20229 INFO dfs.DataNode$PacketResponder: Received block blk_3777389444004341563 of size 67108864 from /10.251.214.175
+081111 045252 20089 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-4578850505370039622 terminating
+081111 045430 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.6.214:50010 is added to blk_4893049344332234616 size 67108864
+081111 045614 20587 INFO dfs.DataNode$DataXceiver: Receiving block blk_9131004320470011870 src: /10.251.123.132:52815 dest: /10.251.123.132:50010
+081111 045623 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand5/_temporary/_task_200811101024_0011_m_000040_0/part-00040. blk_1253515519191706153
+081111 045628 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.214.130:50010 is added to blk_-9056748866943837167 size 67108864
+081111 045751 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.126.22:50010 is added to blk_-8298519990603402919 size 67108864
+081111 045804 20338 INFO dfs.DataNode$PacketResponder: Received block blk_-337972286882621518 of size 67108864 from /10.250.10.144
+081111 045834 19263 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-4411589101766563890 terminating
+081111 045903 20579 INFO dfs.DataNode$DataXceiver: Receiving block blk_-8838632285969241889 src: /10.251.43.21:35844 dest: /10.251.43.21:50010
+081111 045904 20552 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-8225435781013159573 terminating
+081111 045911 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.27.63:50010 is added to blk_-7985144765168396303 size 67108864
+081111 050045 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand5/_temporary/_task_200811101024_0011_m_000541_0/part-00541. blk_-6841570414687342011
+081111 050105 20507 INFO dfs.DataNode$PacketResponder: Received block blk_3924177422736829493 of size 67108864 from /10.251.66.102
+081111 050307 20305 INFO dfs.DataNode$DataXceiver: Receiving block blk_9074726164158535746 src: /10.251.214.32:34409 dest: /10.251.214.32:50010
+081111 050313 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.107.242:50010 is added to blk_-5773244829531118765 size 67108864
+081111 050334 20441 INFO dfs.DataNode$DataXceiver: Received block blk_-4411589101766563890 src: /10.250.14.38:37362 dest: /10.250.14.38:50010 of size 67108864
+081111 050346 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.90.64:50010 is added to blk_-8923923031063738809 size 67108864
+081111 050414 20630 INFO dfs.DataNode$DataXceiver: Receiving block blk_-8703611999267892995 src: /10.250.15.101:32889 dest: /10.250.15.101:50010
+081111 050426 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.15.101:50010 is added to blk_-5352085087037370841 size 67108864
+081111 050534 20462 INFO dfs.DataNode$PacketResponder: Received block blk_1411218759880637753 of size 67108864 from /10.251.123.20
+081111 050710 20499 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-2268450354164990110 terminating
+081111 051005 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.122.79:50010 is added to blk_-3622135859810774312 size 67108864
+081111 051007 21019 INFO dfs.DataNode$DataXceiver: Receiving block blk_-2667669005094349452 src: /10.251.203.149:41751 dest: /10.251.203.149:50010
+081111 051128 20647 INFO dfs.DataNode$PacketResponder: Received block blk_-2935178173527646581 of size 67108864 from /10.251.65.237
+081111 051129 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.107.227:50010 is added to blk_5781791720343455145 size 67108864
+081111 051130 20759 INFO dfs.DataNode$PacketResponder: Received block blk_49420377461855719 of size 67108864 from /10.251.70.112
+081111 051331 20788 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-805262942087665153 terminating
+081111 051411 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.214.225:50010 is added to blk_8323519561483823145 size 67108864
+081111 051513 20482 INFO dfs.DataNode$DataXceiver: Receiving block blk_2208589726473895860 src: /10.251.199.245:33914 dest: /10.251.199.245:50010
+081111 051517 20834 INFO dfs.DataNode$DataXceiver: Receiving block blk_-6618090096819679591 src: /10.251.214.67:58610 dest: /10.251.214.67:50010
+081111 051555 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.42.16:50010 is added to blk_-3253005280055520211 size 67108864
+081111 051726 20622 INFO dfs.DataNode$PacketResponder: Received block blk_-6832799704680039005 of size 67108864 from /10.250.17.225
+081111 051744 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.65.203:50010 is added to blk_4777657900314457675 size 3546628
+081111 051819 20803 INFO dfs.DataNode$PacketResponder: Received block blk_-6464892000340112134 of size 67108864 from /10.250.5.161
+081111 051953 20767 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-8435779070374485499 terminating
+081111 052017 20779 INFO dfs.DataNode$PacketResponder: Received block blk_8993862241777591326 of size 67108864 from /10.250.15.240
+081111 052103 20872 INFO dfs.DataNode$DataXceiver: Receiving block blk_8452214765874767801 src: /10.251.38.197:60409 dest: /10.251.38.197:50010
+081111 052348 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.90.239:50010 is added to blk_-2281067667503210140 size 67108864
+081111 052507 21174 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-4424971182856566289 terminating
+081111 052633 21162 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_2040222317555585426 terminating
+081111 052716 20795 INFO dfs.DataNode$DataXceiver: Receiving block blk_-663653551898848389 src: /10.251.203.149:42756 dest: /10.251.203.149:50010
+081111 052803 21053 INFO dfs.DataNode$DataXceiver: Receiving block blk_-5836693155656083066 src: /10.251.214.67:41233 dest: /10.251.214.67:50010
+081111 052812 21102 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7228803354694123939 src: /10.251.195.70:50389 dest: /10.251.195.70:50010
+081111 052842 21012 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_2953550760670423417 terminating
+081111 052846 21358 INFO dfs.DataNode$PacketResponder: Received block blk_5348548743130215090 of size 67108864 from /10.251.39.179
+081111 052853 20914 INFO dfs.DataNode$PacketResponder: Received block blk_7413830214932763926 of size 67108864 from /10.251.125.174
+081111 053001 20539 INFO dfs.DataNode$PacketResponder: Received block blk_6329639726609402522 of size 67108864 from /10.251.107.19
+081111 053010 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand5/_temporary/_task_200811101024_0011_m_001408_0/part-01408. blk_6601059760261449131
+081111 053158 21003 INFO dfs.DataNode$DataXceiver: Receiving block blk_-5439682406172672049 src: /10.251.42.207:36091 dest: /10.251.42.207:50010
+081111 053245 21296 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7492294065771709299 src: /10.251.203.149:41058 dest: /10.251.203.149:50010
+081111 053325 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.39.144:50010 is added to blk_1526403491950199810 size 3534443
+081111 053347 21024 INFO dfs.DataNode$PacketResponder: Received block blk_8902425017314766082 of size 67108864 from /10.251.26.131
+081111 053359 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand5/_temporary/_task_200811101024_0011_m_001730_0/part-01730. blk_6400082566804273401
+081111 053400 21069 INFO dfs.DataNode$DataXceiver: Receiving block blk_6400082566804273401 src: /10.251.38.214:42160 dest: /10.251.38.214:50010
+081111 053431 20804 INFO dfs.DataNode$PacketResponder: Received block blk_4989329877491629543 of size 67108864 from /10.250.15.67
+081111 053619 21091 INFO dfs.DataNode$DataXceiver: Receiving block blk_-6608350831463251448 src: /10.251.107.196:43317 dest: /10.251.107.196:50010
+081111 053916 21341 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-5580322334454533924 terminating
+081111 053932 21163 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_7500282100357271699 terminating
+081111 053958 21262 INFO dfs.DataNode$DataXceiver: Receiving block blk_8087142318511408355 src: /10.250.15.67:55334 dest: /10.250.15.67:50010
+081111 054004 21237 INFO dfs.DataNode$PacketResponder: Received block blk_-997605125898553536 of size 67108864 from /10.251.30.179
+081111 054018 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.106.37:50010 is added to blk_-4510259260131940043 size 3552141
+081111 054135 21577 INFO dfs.DataNode$PacketResponder: Received block blk_2270593866672608129 of size 67108864 from /10.250.11.53
+081111 054310 21173 INFO dfs.DataNode$PacketResponder: Received block blk_6685663454079607598 of size 10157271 from /10.251.66.3
+081111 054323 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.30.179:50010 is added to blk_-4347054230277727863 size 67108864
+081111 054342 20995 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-1067234447809438340 terminating
+081111 054443 21162 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-1096621677333075077 terminating
+081111 054449 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.125.193:50010 is added to blk_-8657800226489501791 size 3550839
+081111 054504 21552 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_2151150262081352617 terminating
+081111 054731 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_3280859030919654043 is added to invalidSet of 10.251.214.130:50010
+081111 054811 21215 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-6811828069408410657 terminating
+081111 054914 21234 INFO dfs.DataNode$PacketResponder: Received block blk_4967370797322420259 of size 67108864 from /10.251.39.192
+081111 055147 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.127.243:50010 is added to blk_-719178972315562824 size 67108864
+081111 055219 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.67.4:50010 is added to blk_9093176996492793041 size 67108864
+081111 055444 21503 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-7200400342436668240 terminating
+081111 055501 21608 INFO dfs.DataNode$PacketResponder: Received block blk_7213990003235926706 of size 67108864 from /10.250.11.100
+081111 055640 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.7.32:50010 is added to blk_-2125743956855238111 size 67108864
+081111 055936 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.7.244:50010 is added to blk_-4875138366845786590 size 67108864
+081111 060015 21733 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_2508619583759354778 terminating
+081111 060043 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.7.244:50010 is added to blk_6095704128062577668 size 28484260
+081111 060104 21535 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_6123232805286187512 terminating
+081111 060154 21461 INFO dfs.DataNode$DataXceiver: Receiving block blk_6413965758113058023 src: /10.251.199.150:45184 dest: /10.251.199.150:50010
+081111 060244 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.197.226:50010 is added to blk_7275457888263057111 size 67108864
+081111 060510 21849 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_6818232325322327288 terminating
+081111 061043 21809 INFO dfs.DataNode$PacketResponder: Received block blk_-5954527587435406374 of size 67108864 from /10.251.106.10
+081111 061200 21837 INFO dfs.DataNode$PacketResponder: Received block blk_-4358842839092719327 of size 67108864 from /10.250.15.67
+081111 061202 22063 INFO dfs.DataNode$PacketResponder: Received block blk_1489031087420498797 of size 67108864 from /10.251.71.193
+081111 061534 21779 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-615578808743808725 terminating
+081111 061549 21862 INFO dfs.DataNode$PacketResponder: Received block blk_4588471931728384541 of size 67108864 from /10.251.90.81
+081111 061602 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt5/_temporary/_task_200811101024_0012_m_001192_0/part-01192. blk_7720864196601815614
+081111 061707 21528 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-9098645110390099509 terminating
+081111 061713 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.109.209:50010 is added to blk_1129715194117079802 size 67108864
+081111 061730 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt5/_temporary/_task_200811101024_0012_m_000900_0/part-00900. blk_6690143611140381289
+081111 061739 21895 INFO dfs.DataNode$PacketResponder: Received block blk_7463248820468902190 of size 67108864 from /10.251.91.15
+081111 061857 17075 INFO dfs.DataNode$PacketResponder: Received block blk_3961831045048378097 of size 67108864 from /10.251.39.160
+081111 061900 21890 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-6220821375880228145 terminating
+081111 061909 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.66.192:50010 is added to blk_-4405302133414008227 size 67108864
+081111 061921 21913 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_8854625173826438305 terminating
+081111 061926 22010 INFO dfs.DataNode$PacketResponder: Received block blk_8699194381234371727 of size 67108864 from /10.251.214.67
+081111 062002 21694 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-8389657728641837382 terminating
+081111 062029 21573 INFO dfs.DataNode$DataXceiver: Receiving block blk_-5145508449157510071 src: /10.251.203.246:48508 dest: /10.251.203.246:50010
+081111 062038 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.215.50:50010 is added to blk_6675543598756975559 size 67108864
+081111 062102 22250 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-8364400144313355814 terminating
+081111 062238 21812 INFO dfs.DataNode$DataXceiver: Receiving block blk_6108023147232847992 src: /10.251.42.9:43819 dest: /10.251.42.9:50010
+081111 062311 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.66.102:50010 is added to blk_-1932467763723526131 size 67108864
+081111 062353 22087 INFO dfs.DataNode$DataXceiver: Receiving block blk_-8834022217832819265 src: /10.251.105.189:53216 dest: /10.251.105.189:50010
+081111 062628 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt5/_temporary/_task_200811101024_0012_m_001314_0/part-01314. blk_5872617224009342667
+081111 062735 22030 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_4877808040461609832 terminating
+081111 062905 21843 INFO dfs.DataNode$PacketResponder: Received block blk_3049351456771045311 of size 67108864 from /10.251.199.159
+081111 062911 22258 INFO dfs.DataNode$PacketResponder: Received block blk_1247599917761164561 of size 67108864 from /10.251.37.240
+081111 063053 21803 INFO dfs.DataNode$PacketResponder: Received block blk_2616961363639592748 of size 67108864 from /10.251.202.134
+081111 063138 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt5/_temporary/_task_200811101024_0012_m_001529_0/part-01529. blk_-826920518336899809
+081111 063241 22074 INFO dfs.DataNode$PacketResponder: Received block blk_-3436382429367583573 of size 67108864 from /10.251.107.19
+081111 063244 22352 INFO dfs.DataNode$DataXceiver: Receiving block blk_2824047463816148563 src: /10.251.42.84:35776 dest: /10.251.42.84:50010
+081111 063302 21914 INFO dfs.DataNode$PacketResponder: Received block blk_-9211699406261033878 of size 67108864 from /10.251.30.85
+081111 063305 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.214.67:50010 is added to blk_-5961895238114806886 size 28508403
+081111 063316 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.107.19:50010 is added to blk_-2654726224018724510 size 67108864
+081111 063323 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.67.225:50010 is added to blk_-3955287039966096707 size 67108864
+081111 063402 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.75.143:50010 is added to blk_-1379379987510648393 size 67108864
+081111 063413 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt5/_temporary/_task_200811101024_0012_m_001726_0/part-01726. blk_1858805942071850133
+081111 063451 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt5/_temporary/_task_200811101024_0012_m_001554_0/part-01554. blk_5183831565578080242
+081111 063459 21912 INFO dfs.DataNode$DataXceiver: Receiving block blk_3248835454898465560 src: /10.251.42.84:40950 dest: /10.251.42.84:50010
+081111 063514 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt5/_temporary/_task_200811101024_0012_m_001709_0/part-01709. blk_3776895047834644694
+081111 063636 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.43.192:50010 is added to blk_8521306385156958668 size 67108864
+081111 063859 22169 INFO dfs.DataNode$DataXceiver: Receiving block blk_1606295458729964667 src: /10.251.214.32:47910 dest: /10.251.214.32:50010
+081111 063923 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.203.149:50010 is added to blk_-7282356322111075290 size 67108864
+081111 063944 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.122.65:50010 is added to blk_-5330522460969948971 size 67108864
+081111 064011 22583 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_1077394056781488 terminating
+081111 064106 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt5/_temporary/_task_200811101024_0012_m_001709_0/part-01709. blk_6054235487623373096
+081111 064209 22299 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-7256345477493725857 terminating
+081111 064322 6765 INFO dfs.DataNode$PacketResponder: Received block blk_3480684347183600958 of size 67108864 from /10.251.111.209
+081111 064501 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt5/_temporary/_task_200811101024_0012_m_001635_0/part-01635. blk_9034993982993401678
+081111 064603 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.31.5:50010 is added to blk_-1821104627978106102 size 67108864
+081111 064615 22671 INFO dfs.DataNode$DataXceiver: Receiving block blk_8116683912654412228 src: /10.251.39.179:42019 dest: /10.251.39.179:50010
+081111 064710 22306 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-8329840785892216949 terminating
+081111 064806 22602 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_8254500345987409515 terminating
+081111 064823 22556 INFO dfs.DataNode$DataXceiver: Receiving block blk_-4657886075935807358 src: /10.251.31.160:53084 dest: /10.251.31.160:50010
+081111 064835 22032 INFO dfs.DataNode$DataXceiver: Receiving block blk_8201813022998766557 src: /10.251.203.4:51404 dest: /10.251.203.4:50010
+081111 065205 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-4438918035940270891 is added to invalidSet of 10.251.71.193:50010
+081111 065205 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_5616920288053661280 is added to invalidSet of 10.251.42.9:50010
+081111 065206 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_1815340037591016775 is added to invalidSet of 10.250.9.207:50010
+081111 065208 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_2154193600525549460 is added to invalidSet of 10.251.43.147:50010
+081111 065211 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_5580254744888391593 is added to invalidSet of 10.251.201.204:50010
+081111 065217 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-1641081065757890722 is added to invalidSet of 10.251.107.242:50010
+081111 065217 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_5505696082121135363 is added to invalidSet of 10.251.214.130:50010
+081111 065218 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_5689009809369418749 is added to invalidSet of 10.251.91.84:50010
+081111 065220 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_8155177385081669900 is added to invalidSet of 10.251.197.161:50010
+081111 065224 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_247452006316846355 is added to invalidSet of 10.250.6.191:50010
+081111 065224 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_2657997043417110888 is added to invalidSet of 10.250.13.240:50010
+081111 065225 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-323838382557775734 is added to invalidSet of 10.251.202.209:50010
+081111 065225 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-719470845056640928 is added to invalidSet of 10.251.90.64:50010
+081111 065225 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-7999375661905777727 is added to invalidSet of 10.251.106.37:50010
+081111 065226 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-2451769929123196359 is added to invalidSet of 10.251.199.159:50010
+081111 065227 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_3231389654886008065 is added to invalidSet of 10.251.195.52:50010
+081111 065227 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_3637945019239882309 is added to invalidSet of 10.251.198.196:50010
+081111 065229 19 INFO dfs.FSDataset: Deleting block blk_-7423574498760490375 file /mnt/hadoop/dfs/data/current/subdir58/blk_-7423574498760490375
+081111 065254 19 INFO dfs.FSNamesystem: BLOCK* ask 10.250.17.177:50010 to delete  blk_-8570780307468499817 blk_-9122557405432088649 blk_-4393063808227796056 blk_8767569714374844347 blk_7079754042611867581 blk_7608961006114219538 blk_-5017273584996436939 blk_-6537833125980536955 blk_7610838808763810123 blk_3300803097775546532 blk_-5120750586032922592 blk_1577274266662884430 blk_765879159867598347 blk_-9076085976403711202 blk_-3198963348573340497 blk_-4645750029177277209 blk_-5136142986912961316 blk_5677959846373741243 blk_2107477892986152528 blk_-4235116161537008844 blk_6082535783543982566 blk_-4809870147222033236 blk_8818706925296961012 blk_-5203577173046267127 blk_189089569009261656 blk_446299976487589160 blk_-3916247521166632303 blk_-3324962406687427922 blk_-1807424528783081572 blk_-6858401049333055963 blk_6036564204960295926 blk_-8140723044408248078 blk_-3800132731140204959 blk_1716344083117307767 blk_-5194808114606613364 blk_-5473871016976323232 blk_2920934363167004552 blk_8736689095894369097 blk_-7642734632751940776 blk_3408482260833769309 blk_118013751374560901 blk_7963891081239759520 blk_3813114133944383323 blk_3042818489384932576 blk_-4570173726231458270 blk_-1564644006975920581 blk_338095650783321996 blk_3150135312641203550 blk_4285859645577726288 blk_3438772130782939627 blk_2634772258588877972 blk_-6795664812575964130 blk_3923069610304693233 blk_-1782996202120067721 blk_2004418049430157212 blk_1932147224007687756 blk_-582901062969027153 blk_5072240701440032119 blk_-7919006477393039068 blk_-7318022361288598312 blk_-6974693594143537436 blk_-5435767047126325206 blk_-5805500288959332434 blk_-7109885589081848850 blk_2161580591957523893 blk_7240227881194993860 blk_-8298405680648445349 blk_-4253026248821272215 blk_8377661448601579317 blk_8029153852899017155 blk_-8754388319080705916 blk_-7844092300527332901 blk_710178463364063355 blk_-5136849989188547884 blk_8393887138377503163 blk_-6950176077776664217 blk_-6488701068659548195 blk_2537458728254532453 blk_364441107933628577 blk_6207861897580168557 blk_8814943807366894581 blk_-4150682644311695471 blk_9174833667156726933 blk_649427218152856001 blk_-7403541028238011236 blk_-334982586592048773 blk_61908781908925992 blk_6385574357371832424 blk_-66376131060945541 blk_1372596948297458670 blk_-3389135155401857220 blk_-6035411221441929663 blk_-5127580069634421247 blk_-5685246533892022418 blk_4977937528993040451 blk_5680538862600094527 blk_-8378747462487962732 blk_425101290285860876 blk_6306622708327890839 blk_-1067866602168873257
+081111 065258 19 INFO dfs.FSDataset: Deleting block blk_-9169228974826183399 file /mnt/hadoop/dfs/data/current/subdir5/blk_-9169228974826183399
+081111 065303 19 INFO dfs.FSNamesystem: BLOCK* ask 10.250.10.213:50010 to delete  blk_4029139044660806713 blk_-5471189807977280544 blk_6708643067868168687 blk_-500678958150296008 blk_-8597840983621849778 blk_-3610057702150392748 blk_-1709606535283888232 blk_-4154362211643572668 blk_-8892080524136798472 blk_5356427838869009345 blk_-6987238639050161133 blk_-5215128860160823363 blk_7186692462976470823 blk_-6538449588297475521 blk_-2165930080589343952 blk_-5524899010031625427 blk_6384439316405471171 blk_-2965258329365213675 blk_118950937507976810 blk_-1717088081766373300 blk_-3911466865418055820 blk_1237334407720045724 blk_-760015977981369567 blk_-6802007379650646616 blk_-7667535133893574689 blk_6865645438678864855 blk_4633996820313194570 blk_7225301266481603731 blk_-4930257130609958866 blk_-4124845864570823487 blk_4927011145115127531 blk_7234346856930822716 blk_7159969052744592746 blk_1296823600557793869 blk_2209319141644287774 blk_-622218131799806364 blk_-8154516246083521409 blk_4466433199471909449 blk_8406894133999850666 blk_991075908349619367 blk_-2081474832657208733 blk_-5573393775847919985 blk_2004177185950968695 blk_4041319486058127641 blk_6449230045010995668 blk_5978265573904271474 blk_-4813738732036414715 blk_4389340532803855247 blk_-857151863616763327 blk_-7200136644339435027 blk_-1454962873426270839 blk_-5012294311590635938 blk_7112727670634942639 blk_3335012758760643328 blk_3382627815322561484 blk_825124020036421636 blk_-8040559034239258688 blk_-5415591001139074826 blk_-1052513063506891954 blk_-1155882018729560343 blk_-5679835604685169040 blk_-4498808851217768984 blk_8345415947062862337 blk_8521655806854586696 blk_7602939593939794410 blk_-4833650023923869528 blk_7237730029042141635 blk_2860897425785746911 blk_-1937193099911148343 blk_5740615689780260922 blk_963252337613423037 blk_5537011318013544619 blk_2626057344048606017 blk_8296499240199635880 blk_7211071078501521087 blk_8823112510768971040 blk_-3366974935992288326 blk_-2947778702643296262 blk_7693891282153136044 blk_4644812717442758529 blk_-5724970555730638200 blk_-3039294462945223064 blk_-1729755380346651221 blk_-6448673813272428418 blk_-7724282460846954976 blk_2698691234887375588 blk_-4043525878322523713 blk_-5195120009388265 blk_8879208244602324204 blk_-5784376901556131897 blk_-5201149273969117873 blk_5253889604362640423 blk_7067050654303940677 blk_8992626816092659826 blk_-488462739843441981 blk_8543991617360374935 blk_1943146154560599630 blk_-9194660123773136535 blk_3351984198891394382 blk_-6759123807563555545
+081111 065339 22547 INFO dfs.DataNode$PacketResponder: Received block blk_5406084276349645828 of size 67108864 from /10.250.10.223
+081111 065404 22999 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_2016964533702776852 terminating
+081111 065418 18 INFO dfs.FSDataset: Deleting block blk_-1306900105984505600 file /mnt/hadoop/dfs/data/current/subdir31/blk_-1306900105984505600
+081111 065420 19 INFO dfs.FSDataset: Deleting block blk_-1312981516354612257 file /mnt/hadoop/dfs/data/current/subdir29/blk_-1312981516354612257
+081111 065420 19 INFO dfs.FSDataset: Deleting block blk_-2658615574293326723 file /mnt/hadoop/dfs/data/current/subdir37/blk_-2658615574293326723
+081111 065423 19 INFO dfs.FSDataset: Deleting block blk_2107487634698646045 file /mnt/hadoop/dfs/data/current/subdir3/blk_2107487634698646045
+081111 065426 19 INFO dfs.FSDataset: Deleting block blk_-253282915050290778 file /mnt/hadoop/dfs/data/current/subdir23/blk_-253282915050290778
+081111 065435 19 INFO dfs.FSDataset: Deleting block blk_1587615395786683981 file /mnt/hadoop/dfs/data/current/subdir14/blk_1587615395786683981
+081111 065437 19 INFO dfs.FSDataset: Deleting block blk_3706543205492061794 file /mnt/hadoop/dfs/data/current/subdir1/blk_3706543205492061794
+081111 065440 19 INFO dfs.FSDataset: Deleting block blk_3862032846413436284 file /mnt/hadoop/dfs/data/current/subdir28/blk_3862032846413436284
+081111 065444 18 INFO dfs.FSDataset: Deleting block blk_4632283243694149854 file /mnt/hadoop/dfs/data/current/subdir40/blk_4632283243694149854
+081111 065444 19 INFO dfs.FSDataset: Deleting block blk_1018961650823645078 file /mnt/hadoop/dfs/data/current/subdir60/blk_1018961650823645078
+081111 065444 19 INFO dfs.FSDataset: Deleting block blk_1213582438865696738 file /mnt/hadoop/dfs/data/current/subdir56/blk_1213582438865696738
+081111 065445 19 INFO dfs.FSDataset: Deleting block blk_2473550781612396886 file /mnt/hadoop/dfs/data/current/subdir54/blk_2473550781612396886
+081111 065500 19 INFO dfs.FSDataset: Deleting block blk_8102707766842966459 file /mnt/hadoop/dfs/data/current/subdir29/blk_8102707766842966459
+081111 065500 22388 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-352190670750948803 terminating
+081111 065503 19 INFO dfs.FSDataset: Deleting block blk_6491888411266994867 file /mnt/hadoop/dfs/data/current/subdir39/blk_6491888411266994867
+081111 065504 18 INFO dfs.FSDataset: Deleting block blk_3336810835691486095 file /mnt/hadoop/dfs/data/current/subdir11/blk_3336810835691486095
+081111 065510 19 INFO dfs.FSDataset: Deleting block blk_4367982328407767477 file /mnt/hadoop/dfs/data/current/subdir28/blk_4367982328407767477
+081111 065511 19 INFO dfs.FSDataset: Deleting block blk_6943254721518837570 file /mnt/hadoop/dfs/data/current/subdir41/blk_6943254721518837570
+081111 065515 19 INFO dfs.FSDataset: Deleting block blk_6077744985764117617 file /mnt/hadoop/dfs/data/current/subdir17/blk_6077744985764117617
+081111 065526 22651 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_6975937964598933356 terminating
+081111 065538 19 INFO dfs.FSDataset: Deleting block blk_5771906433100975293 file /mnt/hadoop/dfs/data/current/subdir37/blk_5771906433100975293
+081111 065605 22827 INFO dfs.DataNode$DataXceiver: Receiving block blk_-3884471885525630813 src: /10.251.106.50:60327 dest: /10.251.106.50:50010
+081111 065705 22525 INFO dfs.DataNode$DataXceiver: Receiving block blk_8596624696139957935 src: /10.251.214.175:41468 dest: /10.251.214.175:50010
+081111 065705 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand6/_temporary/_task_200811101024_0013_m_000153_0/part-00153. blk_8596624696139957935
+081111 065803 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.214.67:50010 is added to blk_-8483420270408348004 size 67108864
+081111 065804 19 INFO dfs.FSDataset: Deleting block blk_4506604798892399878 file /mnt/hadoop/dfs/data/current/subdir0/blk_4506604798892399878
+081111 065920 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand6/_temporary/_task_200811101024_0013_m_000197_0/part-00197. blk_1832308388558480
+081111 065936 22801 INFO dfs.DataNode$PacketResponder: Received block blk_2247786307216183697 of size 67108864 from /10.251.67.4
+081111 070022 22093 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-4289592006812254261 terminating
+081111 070040 22706 INFO dfs.DataNode$DataXceiver: Receiving block blk_5989505185938770383 src: /10.251.67.4:53429 dest: /10.251.67.4:50010
+081111 070055 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.121.224:50010 is added to blk_3134656542322449478 size 67108864
+081111 070232 13 INFO dfs.DataBlockScanner: Verification succeeded for blk_-8050165297538775793
+081111 070246 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.90.134:50010 is added to blk_-3184700311670257792 size 67108864
+081111 070258 22788 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_5114572025256210948 terminating
+081111 070301 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand6/_temporary/_task_200811101024_0013_m_000451_0/part-00451. blk_-8744988583359134013
+081111 070326 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand6/_temporary/_task_200811101024_0013_m_000079_0/part-00079. blk_4225726256421431188
+081111 070458 22933 INFO dfs.DataNode$PacketResponder: Received block blk_1060814796407897179 of size 67108864 from /10.251.109.209
+081111 070505 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.25.237:50010 is added to blk_-1496429201748767714 size 67108864
+081111 070519 22971 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-4684475480143348818 terminating
+081111 070519 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand6/_temporary/_task_200811101024_0013_m_000077_0/part-00077. blk_608957629753483727
+081111 070635 22203 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-7937864120968665564 terminating
+081111 070735 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.214.130:50010 is added to blk_-4427507243535536615 size 67108864
+081111 070823 22537 INFO dfs.DataNode$PacketResponder: Received block blk_7830067201550857864 of size 67108864 from /10.251.105.189
+081111 070836 22330 INFO dfs.DataNode$PacketResponder: Received block blk_-2194976790278647102 of size 67108864 from /10.251.110.8
+081111 070836 23168 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_8459274965060101250 terminating
+081111 070912 22946 INFO dfs.DataNode$PacketResponder: Received block blk_1561008813520212225 of size 67108864 from /10.250.7.230
+081111 070918 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.6.214:50010 is added to blk_5963655886023015963 size 67108864
+081111 070928 23133 INFO dfs.DataNode$DataXceiver: Receiving block blk_2377944115560974127 src: /10.251.75.163:55681 dest: /10.251.75.163:50010
+081111 071020 22762 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_6030936529326346827 terminating
+081111 071027 22865 INFO dfs.DataNode$DataXceiver: Receiving block blk_3322875843051058970 src: /10.250.7.244:40195 dest: /10.250.7.244:50010
+081111 071037 21663 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-7269672042149855641 terminating
+081111 071042 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.30.134:50010 is added to blk_-5214060566378896158 size 67108864
+081111 071112 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand6/_temporary/_task_200811101024_0013_m_000523_0/part-00523. blk_-4801855948459616884
+081111 071205 23083 INFO dfs.DataNode$PacketResponder: Received block blk_-4846710336436578833 of size 67108864 from /10.251.203.129
+081111 071331 22956 INFO dfs.DataNode$PacketResponder: Received block blk_-1522107359378428427 of size 67108864 from /10.251.125.174
+081111 071510 22974 INFO dfs.DataNode$PacketResponder: Received block blk_-1846853350696018836 of size 67108864 from /10.250.15.67
+081111 071611 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand6/_temporary/_task_200811101024_0013_m_000997_0/part-00997. blk_-500534246236005335
+081111 071713 23240 INFO dfs.DataNode$PacketResponder: Received block blk_-1236077201457689973 of size 67108864 from /10.251.35.1
+081111 071731 23039 INFO dfs.DataNode$PacketResponder: Received block blk_8474920544984206742 of size 67108864 from /10.251.91.229
+081111 071746 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.71.16:50010 is added to blk_-6464763289185102366 size 67108864
+081111 071904 22560 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7646004878694144580 src: /10.251.202.181:47130 dest: /10.251.202.181:50010
+081111 071912 23232 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-41928108292416895 terminating
+081111 071939 22914 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7389979618829759505 src: /10.251.127.47:58395 dest: /10.251.127.47:50010
+081111 072053 23570 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_2096030750186708493 terminating
+081111 072059 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.30.6:50010 is added to blk_-2345355483730155757 size 67108864
+081111 072214 23052 INFO dfs.DataNode$PacketResponder: Received block blk_5834218936335592624 of size 67108864 from /10.251.111.228
+081111 072224 23062 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-5504500392858491441 terminating
+081111 072300 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.17.177:50010 is added to blk_4385764838827095986 size 3541872
+081111 072355 22702 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-3710747952520609225 terminating
+081111 072356 23300 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_707166530951154301 terminating
+081111 072356 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.126.22:50010 is added to blk_707166530951154301 size 67108864
+081111 072403 23051 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_2241654010576170013 terminating
+081111 072447 23098 INFO dfs.DataNode$DataXceiver: Receiving block blk_-8475679647841427708 src: /10.251.75.49:58661 dest: /10.251.75.49:50010
+081111 072523 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.27.63:50010 is added to blk_-7794786562417612249 size 67108864
+081111 072710 22924 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-2068111211565768713 terminating
+081111 072733 23446 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7238035741206373733 src: /10.251.202.209:59561 dest: /10.251.202.209:50010
+081111 072818 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand6/_temporary/_task_200811101024_0013_m_001195_0/part-01195. blk_5708405953850477535
+081111 072857 23371 INFO dfs.DataNode$PacketResponder: Received block blk_2253084440592362960 of size 67108864 from /10.251.199.19
+081111 072901 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.91.32:50010 is added to blk_-8127580564011467092 size 67108864
+081111 072903 23158 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-8568673600040025636 terminating
+081111 072921 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.107.242:50010 is added to blk_621685330749869453 size 67108864
+081111 072948 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.7.230:50010 is added to blk_8663640697928077697 size 67108864
+081111 072949 23644 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_1508705816376906895 terminating
+081111 072956 23082 INFO dfs.DataNode$PacketResponder: Received block blk_-6441360440068187612 of size 67108864 from /10.250.10.100
+081111 073005 23505 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_2128110944185709079 terminating
+081111 073013 23372 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_871974742726663441 terminating
+081111 073059 23319 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_8049943837789435742 terminating
+081111 073109 23004 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-8246207776580662770 terminating
+081111 073148 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.11.100:50010 is added to blk_3406384548372443486 size 67108864
+081111 073230 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.193.175:50010 is added to blk_2460145905812664251 size 67108864
+081111 073302 23438 INFO dfs.DataNode$PacketResponder: Received block blk_-7207514537719465756 of size 67108864 from /10.251.75.143
+081111 073314 23367 INFO dfs.DataNode$DataXceiver: Receiving block blk_5216491057643255876 src: /10.251.105.189:55126 dest: /10.251.105.189:50010
+081111 073350 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.7.96:50010 is added to blk_4641147544753118391 size 67108864
+081111 073403 23490 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-85872290979354091 terminating
+081111 073406 23140 INFO dfs.DataNode$PacketResponder: Received block blk_-8310554294841246175 of size 67108864 from /10.251.123.132
+081111 073441 17869 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7293871043749246063 src: /10.251.193.175:59757 dest: /10.251.193.175:50010
+081111 073507 23329 INFO dfs.DataNode$PacketResponder: Received block blk_3107521534415119817 of size 67108864 from /10.251.193.224
+081111 073525 23203 INFO dfs.DataNode$PacketResponder: Received block blk_7194943883245628915 of size 67108864 from /10.251.71.193
+081111 073610 23484 INFO dfs.DataNode$PacketResponder: Received block blk_-3816036740130815667 of size 3547785 from /10.250.19.227
+081111 073704 23532 INFO dfs.DataNode$PacketResponder: Received block blk_-5450224419450631495 of size 67108864 from /10.251.42.84
+081111 073746 23412 INFO dfs.DataNode$DataXceiver: Receiving block blk_5881782374981838094 src: /10.251.214.18:43091 dest: /10.251.214.18:50010
+081111 073802 23624 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_7078766226078740026 terminating
+081111 073914 23367 INFO dfs.DataNode$PacketResponder: Received block blk_-7380871572601322244 of size 67108864 from /10.251.121.224
+081111 073943 23467 INFO dfs.DataNode$DataXceiver: Receiving block blk_3846795603907041885 src: /10.250.10.176:47296 dest: /10.250.10.176:50010
+081111 073949 23599 INFO dfs.DataNode$PacketResponder: Received block blk_7922331746517419368 of size 67108864 from /10.251.199.19
+081111 074108 23144 INFO dfs.DataNode$PacketResponder: Received block blk_155320394753274773 of size 67108864 from /10.251.201.204
+081111 074200 23325 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-5722491454804415982 terminating
+081111 074309 23736 INFO dfs.DataNode$PacketResponder: Received block blk_-3482997549732691785 of size 67108864 from /10.251.122.79
+081111 074409 23194 INFO dfs.DataNode$DataXceiver: Receiving block blk_6417614801998326532 src: /10.251.214.67:48694 dest: /10.251.214.67:50010
+081111 074431 23560 INFO dfs.DataNode$PacketResponder: Received block blk_-1090213273274684471 of size 67108864 from /10.251.214.130
+081111 074449 23551 INFO dfs.DataNode$DataXceiver: Receiving block blk_-3738901473077208093 src: /10.251.199.150:49679 dest: /10.251.199.150:50010
+081111 074540 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand6/_temporary/_task_200811101024_0013_m_001850_0/part-01850. blk_-4312777901444596370
+081111 074548 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand6/_temporary/_task_200811101024_0013_m_001835_0/part-01835. blk_6178964531181542074
+081111 074653 23823 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_8550326614414622861 terminating
+081111 074955 23635 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-6525012344542022819 terminating
+081111 074958 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand6/_temporary/_task_200811101024_0013_m_001983_0/part-01983. blk_8861349372992394289
+081111 075054 23885 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-1049340855430710153 terminating
+081111 075114 23523 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_703049809255765647 terminating
+081111 075129 23397 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7460532841070848624 src: /10.250.15.67:55076 dest: /10.250.15.67:50010
+081111 075151 23925 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7623732795385061487 src: /10.251.122.65:40641 dest: /10.251.122.65:50010
+081111 075158 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand6/_temporary/_task_200811101024_0013_m_002009_1/part-02009. blk_-7367386750462511488
+081111 075212 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.111.228:50010 is added to blk_-1237539644269634790 size 67108864
+081111 075317 23851 INFO dfs.DataNode$DataXceiver: Receiving block blk_7713504868233504097 src: /10.251.127.191:36437 dest: /10.251.127.191:50010
+081111 075345 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.65.203:50010 is added to blk_8005746184358076390 size 67108864
+081111 075408 23362 INFO dfs.DataNode$PacketResponder: Received block blk_955083461510572332 of size 41287838 from /10.251.107.242
+081111 075537 23945 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_283922378823540530 terminating
+081111 075616 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_4471044334742081825 is added to invalidSet of 10.250.15.198:50010
+081111 075619 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-3671953658029337449 is added to invalidSet of 10.250.14.143:50010
+081111 075623 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-75893538967225087 is added to invalidSet of 10.250.15.198:50010
+081111 075626 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_805187982300776163 is added to invalidSet of 10.251.73.188:50010
+081111 075628 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_4631777956354958682 is added to invalidSet of 10.251.30.134:50010
+081111 075629 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-7595375726951801956 is added to invalidSet of 10.251.122.79:50010
+081111 075631 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-4681205519208992498 is added to invalidSet of 10.250.6.191:50010
+081111 075632 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_5702487846232575705 is added to invalidSet of 10.250.14.38:50010
+081111 075634 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_4834069779372284635 is added to invalidSet of 10.251.71.97:50010
+081111 075636 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_3735517274901501821 is added to invalidSet of 10.250.6.4:50010
+081111 075637 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_5018797996887008111 is added to invalidSet of 10.251.89.155:50010
+081111 075638 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-566178736644429906 is added to invalidSet of 10.251.70.37:50010
+081111 075640 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-8121498678081035000 is added to invalidSet of 10.250.11.100:50010
+081111 075657 23748 INFO dfs.DataNode$DataXceiver: Receiving block blk_7996616083434301906 src: /10.251.123.195:53947 dest: /10.251.123.195:50010
+081111 075727 19 INFO dfs.FSDataset: Deleting block blk_6888300867578983331 file /mnt/hadoop/dfs/data/current/subdir46/blk_6888300867578983331
+081111 075743 23596 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_7625391056418655045 terminating
+081111 075746 19 INFO dfs.FSDataset: Deleting block blk_-8443921001690182522 file /mnt/hadoop/dfs/data/current/subdir33/blk_-8443921001690182522
+081111 075747 23844 INFO dfs.DataNode$DataXceiver: Receiving block blk_706826531153199550 src: /10.250.5.161:58254 dest: /10.250.5.161:50010
+081111 075753 19 INFO dfs.FSDataset: Deleting block blk_-7446091384471755694 file /mnt/hadoop/dfs/data/current/subdir30/blk_-7446091384471755694
+081111 075759 19 INFO dfs.FSDataset: Deleting block blk_-4352313989800650828 file /mnt/hadoop/dfs/data/current/subdir56/blk_-4352313989800650828
+081111 075809 19 INFO dfs.FSDataset: Deleting block blk_-6292499669518281202 file /mnt/hadoop/dfs/data/current/subdir26/blk_-6292499669518281202
+081111 075809 23659 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-4582442491366282435 terminating
+081111 075810 19 INFO dfs.FSDataset: Deleting block blk_-6750694665033046901 file /mnt/hadoop/dfs/data/current/subdir63/blk_-6750694665033046901
+081111 075814 19 INFO dfs.FSDataset: Deleting block blk_-6131345369657245178 file /mnt/hadoop/dfs/data/current/blk_-6131345369657245178
+081111 075824 19 INFO dfs.FSDataset: Deleting block blk_-3575718350717794894 file /mnt/hadoop/dfs/data/current/blk_-3575718350717794894
+081111 075833 19 INFO dfs.FSDataset: Deleting block blk_-4380385204018751771 file /mnt/hadoop/dfs/data/current/subdir38/blk_-4380385204018751771
+081111 075838 19 INFO dfs.FSDataset: Deleting block blk_-3594701313167635091 file /mnt/hadoop/dfs/data/current/subdir54/blk_-3594701313167635091
+081111 075844 18 INFO dfs.FSDataset: Deleting block blk_-1693418636466747515 file /mnt/hadoop/dfs/data/current/subdir16/blk_-1693418636466747515
+081111 075854 19 INFO dfs.FSDataset: Deleting block blk_5806397523737304814 file /mnt/hadoop/dfs/data/current/subdir34/blk_5806397523737304814
+081111 075901 18 INFO dfs.FSDataset: Deleting block blk_-1345585044778938153 file /mnt/hadoop/dfs/data/current/subdir45/blk_-1345585044778938153
+081111 075901 19 INFO dfs.FSDataset: Deleting block blk_2489882700357182381 file /mnt/hadoop/dfs/data/current/blk_2489882700357182381
+081111 075902 19 INFO dfs.FSDataset: Deleting block blk_-1800458850981311953 file /mnt/hadoop/dfs/data/current/subdir57/blk_-1800458850981311953
+081111 075905 19 INFO dfs.FSDataset: Deleting block blk_6373260430960091026 file /mnt/hadoop/dfs/data/current/subdir43/blk_6373260430960091026
+081111 075907 19 INFO dfs.FSDataset: Deleting block blk_-1278725622357466169 file /mnt/hadoop/dfs/data/current/subdir0/blk_-1278725622357466169
+081111 075911 19 INFO dfs.FSDataset: Deleting block blk_4513772639980123655 file /mnt/hadoop/dfs/data/current/blk_4513772639980123655
+081111 075914 19 INFO dfs.FSDataset: Deleting block blk_1838564958520120941 file /mnt/hadoop/dfs/data/current/subdir39/blk_1838564958520120941
+081111 075915 19 INFO dfs.FSDataset: Deleting block blk_7985460426680885040 file /mnt/hadoop/dfs/data/current/blk_7985460426680885040
+081111 075920 19 INFO dfs.FSDataset: Deleting block blk_2215517976324634098 file /mnt/hadoop/dfs/data/current/subdir4/blk_2215517976324634098
+081111 075920 19 INFO dfs.FSDataset: Deleting block blk_5453150794205420798 file /mnt/hadoop/dfs/data/current/subdir24/blk_5453150794205420798
+081111 075933 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.194.102:50010 is added to blk_-7522572236891389139 size 67108864
+081111 075957 19 INFO dfs.FSDataset: Deleting block blk_6163400028286940197 file /mnt/hadoop/dfs/data/current/subdir7/blk_6163400028286940197
+081111 080006 19 INFO dfs.FSDataset: Deleting block blk_7583807825342916938 file /mnt/hadoop/dfs/data/current/subdir13/blk_7583807825342916938
+081111 080019 23787 INFO dfs.DataNode$DataXceiver: Receiving block blk_-5957060034695163774 src: /10.251.29.239:56334 dest: /10.251.29.239:50010
+081111 080108 24040 INFO dfs.DataNode$DataXceiver: Receiving block blk_-2250942073136893488 src: /10.251.126.22:59179 dest: /10.251.126.22:50010
+081111 080118 23798 INFO dfs.DataNode$PacketResponder: Received block blk_-3693786175267111588 of size 67108864 from /10.251.71.97
+081111 080151 19 INFO dfs.FSDataset: Deleting block blk_8384967715738359346 file /mnt/hadoop/dfs/data/current/subdir27/blk_8384967715738359346
+081111 080256 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.10.223:50010 is added to blk_-1948505589144820414 size 67108864
+081111 080309 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.202.209:50010 is added to blk_-6224982681533811277 size 67108864
+081111 080329 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.107.196:50010 is added to blk_-2843780069100181052 size 67108864
+081111 080505 23478 INFO dfs.DataNode$DataXceiver: Receiving block blk_8083872765147994327 src: /10.250.15.67:41990 dest: /10.250.15.67:50010
+081111 080554 24194 INFO dfs.DataNode$PacketResponder: Received block blk_-6502143621885580798 of size 67108864 from /10.251.39.179
+081111 080645 23938 INFO dfs.DataNode$DataXceiver: Receiving block blk_-8323785930877970805 src: /10.250.13.240:40589 dest: /10.250.13.240:50010
+081111 080654 23600 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-7587189852169913514 terminating
+081111 080710 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.74.192:50010 is added to blk_7439201509602018752 size 67108864
+081111 080803 24149 INFO dfs.DataNode$PacketResponder: Received block blk_3224184805694764748 of size 67108864 from /10.250.18.114
+081111 080934 19 INFO dfs.FSNamesystem: BLOCK* ask 10.250.14.38:50010 to replicate blk_-7571492020523929240 to datanode(s) 10.251.122.38:50010
+081111 081027 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.30.6:50010 is added to blk_1119272693889755844 size 67108864
+081111 081029 24268 INFO dfs.DataNode$PacketResponder: Received block blk_1600228140214754078 of size 67108864 from /10.251.90.81
+081111 081055 24136 INFO dfs.DataNode$DataXceiver: Received block blk_1473949624670719319 src: /10.251.29.239:35617 dest: /10.251.29.239:50010 of size 67108864
+081111 081145 23823 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7227576651324043655 src: /10.251.107.227:40740 dest: /10.251.107.227:50010
+081111 081406 18 INFO dfs.FSDataset: Deleting block blk_-7606467001548719462 file /mnt/hadoop/dfs/data/current/subdir2/blk_-7606467001548719462
+081111 081416 24027 INFO dfs.DataNode$PacketResponder: Received block blk_2771018387166611008 of size 67108864 from /10.251.26.131
+081111 081534 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.110.160:50010 is added to blk_-2852294661215451806 size 67108864
+081111 081606 23925 INFO dfs.DataNode$DataXceiver: Receiving block blk_7891129742741763034 src: /10.251.107.227:57000 dest: /10.251.107.227:50010
+081111 081617 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.15.240:50010 is added to blk_8512974147315737844 size 67108864
+081111 081640 23985 INFO dfs.DataNode$PacketResponder: Received block blk_427477290315080955 of size 67108864 from /10.251.123.132
+081111 081702 24075 INFO dfs.DataNode$PacketResponder: Received block blk_-7630699912570186723 of size 67108864 from /10.251.71.240
+081111 081847 24224 INFO dfs.DataNode$DataXceiver: Receiving block blk_1512136249403454074 src: /10.250.7.244:47958 dest: /10.250.7.244:50010
+081111 081938 23963 INFO dfs.DataNode$PacketResponder: Received block blk_8655748951361667770 of size 67108864 from /10.251.109.236
+081111 081954 24553 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_8487226415276391460 terminating
+081111 082005 23974 INFO dfs.DataNode$DataXceiver: Receiving block blk_-8162657657061473938 src: /10.251.26.131:35484 dest: /10.251.26.131:50010
+081111 082039 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.66.3:50010 is added to blk_-4970213618915792510 size 67108864
+081111 082108 24348 INFO dfs.DataNode$DataXceiver: Receiving block blk_9034824096129858680 src: /10.250.6.223:45371 dest: /10.250.6.223:50010
+081111 082322 24292 INFO dfs.DataNode$PacketResponder: Received block blk_-4775386099844009890 of size 67108864 from /10.251.107.19
+081111 082527 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand7/_temporary/_task_200811101024_0014_m_001049_0/part-01049. blk_-1533191386601391937
+081111 082528 24365 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_2096199637324483321 terminating
+081111 082541 24284 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_3433046099598424314 terminating
+081111 082650 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.13.240:50010 is added to blk_4170936278386288557 size 67108864
+081111 082730 24531 INFO dfs.DataNode$PacketResponder: Received block blk_-3023983271692989109 of size 67108864 from /10.251.110.68
+081111 082809 24442 INFO dfs.DataNode$DataXceiver: Receiving block blk_469126362137371425 src: /10.251.199.245:53897 dest: /10.251.199.245:50010
+081111 082902 24331 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_3922791077126964673 terminating
+081111 082952 24363 INFO dfs.DataNode$PacketResponder: Received block blk_5813923864071791162 of size 67108864 from /10.251.125.193
+081111 082955 24432 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_7412933088374169877 terminating
+081111 083120 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.39.192:50010 is added to blk_-3888538223380979891 size 67108864
+081111 083143 24261 INFO dfs.DataNode$PacketResponder: Received block blk_-5970165518655489569 of size 67108864 from /10.250.14.196
+081111 083148 24344 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-7319442762668598889 terminating
+081111 083212 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand7/_temporary/_task_200811101024_0014_m_000973_0/part-00973. blk_5844313985011885282
+081111 083219 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand7/_temporary/_task_200811101024_0014_m_001348_0/part-01348. blk_4531288786306744275
+081111 083336 24444 INFO dfs.DataNode$PacketResponder: Received block blk_-3845286823494684378 of size 67108864 from /10.251.107.196
+081111 083338 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.203.129:50010 is added to blk_6170586659371027531 size 67108864
+081111 083418 24490 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-808401720390253471 terminating
+081111 083426 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.123.33:50010 is added to blk_1447281351164457761 size 67108864
+081111 083427 24635 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7911408976820434495 src: /10.251.42.191:35834 dest: /10.251.42.191:50010
+081111 083439 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.89.155:50010 is added to blk_-5455316994110506037 size 67108864
+081111 083443 24635 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-917268749136585019 terminating
+081111 083506 24609 INFO dfs.DataNode$DataXceiver: Receiving block blk_1122812501843755360 src: /10.251.198.196:51036 dest: /10.251.198.196:50010
+081111 083742 24575 INFO dfs.DataNode$DataXceiver: Receiving block blk_5983149244832683042 src: /10.251.42.191:52748 dest: /10.251.42.191:50010
+081111 083753 24539 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-5263787695149681326 terminating
+081111 083755 24394 INFO dfs.DataNode$DataXceiver: Receiving block blk_5781019224640206392 src: /10.250.11.194:37060 dest: /10.250.11.194:50010
+081111 083839 24534 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_4786794545180705888 terminating
+081111 083839 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.73.220:50010 is added to blk_1303107722036031233 size 67108864
+081111 083955 24547 INFO dfs.DataNode$PacketResponder: Received block blk_4539833452749813987 of size 67108864 from /10.251.42.16
+081111 084003 24758 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_703387617548630438 terminating
+081111 084102 24677 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_5689516499354445029 terminating
+081111 084148 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.11.100:50010 is added to blk_-4595094649363595358 size 67108864
+081111 084149 24657 INFO dfs.DataNode$DataXceiver: Receiving block blk_-1733026139299872187 src: /10.251.29.239:52800 dest: /10.251.29.239:50010
+081111 084214 24555 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-1910608563003942187 terminating
+081111 084228 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand7/_temporary/_task_200811101024_0014_m_001394_0/part-01394. blk_-1101091099241306483
+081111 084233 24661 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_7901008236334420364 terminating
+081111 084322 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.42.207:50010 is added to blk_2119401975697524206 size 67108864
+081111 084405 24786 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_6204056282927975796 terminating
+081111 084423 24772 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_215466486430758887 terminating
+081111 084619 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand7/_temporary/_task_200811101024_0014_m_001736_0/part-01736. blk_-3055230140330616860
+081111 084721 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.73.220:50010 is added to blk_4473390551542202999 size 67108864
+081111 084728 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand7/_temporary/_task_200811101024_0014_m_001649_0/part-01649. blk_-5581540863377925517
+081111 084732 24650 INFO dfs.DataNode$PacketResponder: Received block blk_7864850143895703065 of size 67108864 from /10.251.107.98
+081111 084757 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.91.32:50010 is added to blk_423916008836295480 size 67108864
+081111 084759 24704 INFO dfs.DataNode$DataXceiver: Receiving block blk_2166777223671724319 src: /10.251.214.175:52741 dest: /10.251.214.175:50010
+081111 084818 25055 INFO dfs.DataNode$PacketResponder: Received block blk_4031738712701565209 of size 67108864 from /10.251.199.150
+081111 084831 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand7/_temporary/_task_200811101024_0014_m_001940_0/part-01940. blk_1910319264393500537
+081111 084842 24787 INFO dfs.DataNode$PacketResponder: Received block blk_-8789402864074203800 of size 67108864 from /10.251.193.224
+081111 084906 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.17.177:50010 is added to blk_5733038550092620376 size 67108864
+081111 085059 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand7/_temporary/_task_200811101024_0014_m_001642_0/part-01642. blk_8215843708467112607
+081111 085146 24834 INFO dfs.DataNode$PacketResponder: Received block blk_-954856062493437881 of size 67108864 from /10.251.106.10
+081111 085221 24607 INFO dfs.DataNode$PacketResponder: Received block blk_241585185788373386 of size 67108864 from /10.251.111.80
+081111 085351 24958 INFO dfs.DataNode$DataXceiver: Receiving block blk_3808164640986377400 src: /10.251.75.79:36685 dest: /10.251.75.79:50010
+081111 085429 25314 INFO dfs.DataNode$PacketResponder: Received block blk_-6719337521981113643 of size 3538321 from /10.250.15.198
+081111 085432 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.197.226:50010 is added to blk_-23492739449820023 size 67108864
+081111 085502 24832 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-8969188698416564850 terminating
+081111 085529 24695 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-5144548163293169177 terminating
+081111 085620 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.122.79:50010 is added to blk_-2895171018912807248 size 67108864
+081111 085634 24881 INFO dfs.DataNode$DataXceiver: Receiving block blk_-5892603381347650390 src: /10.250.14.143:57484 dest: /10.250.14.143:50010
+081111 085634 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand7/_temporary/_task_200811101024_0014_m_002007_0/part-02007. blk_7908524857056299716
+081111 085859 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_3492869167398569662 is added to invalidSet of 10.250.5.161:50010
+081111 085906 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-3894803026385053344 is added to invalidSet of 10.251.43.21:50010
+081111 085906 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-7873581794069372986 is added to invalidSet of 10.251.194.147:50010
+081111 085907 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_2060553104861908174 is added to invalidSet of 10.251.201.204:50010
+081111 085909 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-6783506473540833076 is added to invalidSet of 10.251.202.209:50010
+081111 085910 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-8863130543753323383 is added to invalidSet of 10.251.123.1:50010
+081111 085911 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-8769398708439834546 is added to invalidSet of 10.251.127.243:50010
+081111 085912 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-3316519570098743145 is added to invalidSet of 10.251.70.211:50010
+081111 085912 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-6068451475575444798 is added to invalidSet of 10.251.43.210:50010
+081111 085912 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-7709713535298137702 is added to invalidSet of 10.251.215.50:50010
+081111 085914 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-1030832046197982436 is added to invalidSet of 10.251.89.155:50010
+081111 085914 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_4738781172941319823 is added to invalidSet of 10.251.91.32:50010
+081111 085916 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_2869833078504290822 is added to invalidSet of 10.251.123.132:50010
+081111 085916 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-6261136177206340449 is added to invalidSet of 10.251.70.37:50010
+081111 085917 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-1755309160709170318 is added to invalidSet of 10.251.39.209:50010
+081111 085917 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-8312238797251504127 is added to invalidSet of 10.251.89.155:50010
+081111 085922 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_2713941272199175167 is added to invalidSet of 10.251.38.53:50010
+081111 085922 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-7846283874350947646 is added to invalidSet of 10.251.199.150:50010
+081111 085924 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-793506372912437289 is added to invalidSet of 10.250.17.225:50010
+081111 085926 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_-5293091556505218722 is added to invalidSet of 10.251.125.237:50010
+081111 085929 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.delete: blk_4516306414837452219 is added to invalidSet of 10.251.127.47:50010
+081111 090008 19 INFO dfs.FSDataset: Deleting block blk_-8792837405349224102 file /mnt/hadoop/dfs/data/current/subdir35/blk_-8792837405349224102
+081111 090031 19 INFO dfs.FSDataset: Deleting block blk_-8131422413299851907 file /mnt/hadoop/dfs/data/current/subdir46/blk_-8131422413299851907
+081111 090034 24870 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-2268477281422551537 terminating
+081111 090056 19 INFO dfs.FSDataset: Deleting block blk_-6177194341369822651 file /mnt/hadoop/dfs/data/current/subdir38/blk_-6177194341369822651
+081111 090113 18 INFO dfs.FSDataset: Deleting block blk_1369784431092292099 file /mnt/hadoop/dfs/data/current/subdir36/blk_1369784431092292099
+081111 090113 19 INFO dfs.FSDataset: Deleting block blk_-8060252929692927663 file /mnt/hadoop/dfs/data/current/subdir21/blk_-8060252929692927663
+081111 090118 19 INFO dfs.FSDataset: Deleting block blk_-5344266425789048231 file /mnt/hadoop/dfs/data/current/subdir47/blk_-5344266425789048231
+081111 090126 19 INFO dfs.FSDataset: Deleting block blk_-2518425063392446785 file /mnt/hadoop/dfs/data/current/subdir6/blk_-2518425063392446785
+081111 090129 19 INFO dfs.FSDataset: Deleting block blk_-5598693099021996971 file /mnt/hadoop/dfs/data/current/subdir19/blk_-5598693099021996971
+081111 090131 19 INFO dfs.FSDataset: Deleting block blk_901963876338651405 file /mnt/hadoop/dfs/data/current/subdir1/blk_901963876338651405
+081111 090136 19 INFO dfs.FSDataset: Deleting block blk_-2722768686407017386 file /mnt/hadoop/dfs/data/current/subdir36/blk_-2722768686407017386
+081111 090138 19 INFO dfs.FSDataset: Deleting block blk_92946806844541836 file /mnt/hadoop/dfs/data/current/subdir59/blk_92946806844541836
+081111 090139 19 INFO dfs.FSDataset: Deleting block blk_1824928871191121429 file /mnt/hadoop/dfs/data/current/subdir2/blk_1824928871191121429
+081111 090140 18 INFO dfs.FSDataset: Deleting block blk_-4301178988618507084 file /mnt/hadoop/dfs/data/current/subdir46/blk_-4301178988618507084
+081111 090140 19 INFO dfs.FSDataset: Deleting block blk_-2098161025946048013 file /mnt/hadoop/dfs/data/current/subdir17/blk_-2098161025946048013
+081111 090149 19 INFO dfs.FSDataset: Deleting block blk_-1451819169209310732 file /mnt/hadoop/dfs/data/current/subdir23/blk_-1451819169209310732
+081111 090150 19 INFO dfs.FSDataset: Deleting block blk_2403370969415186087 file /mnt/hadoop/dfs/data/current/subdir6/blk_2403370969415186087
+081111 090154 19 INFO dfs.FSDataset: Deleting block blk_5701964561533648583 file /mnt/hadoop/dfs/data/current/subdir10/blk_5701964561533648583
+081111 090159 19 INFO dfs.FSDataset: Deleting block blk_4007982883396598426 file /mnt/hadoop/dfs/data/current/subdir13/blk_4007982883396598426
+081111 090207 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.197.161:50010 is added to blk_-3724350946705225881 size 67108864
+081111 090208 19 INFO dfs.FSDataset: Deleting block blk_6051144263842600010 file /mnt/hadoop/dfs/data/current/subdir42/blk_6051144263842600010
+081111 090223 19 INFO dfs.FSDataset: Deleting block blk_8436095180790908547 file /mnt/hadoop/dfs/data/current/subdir43/blk_8436095180790908547
+081111 090229 18 INFO dfs.FSDataset: Deleting block blk_5100975846124291571 file /mnt/hadoop/dfs/data/current/subdir38/blk_5100975846124291571
+081111 090246 19 INFO dfs.FSDataset: Deleting block blk_-4941547144875557718 file /mnt/hadoop/dfs/data/current/subdir61/blk_-4941547144875557718
+081111 090339 24904 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_6791628131402590260 terminating
+081111 090816 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.107.196:50010 is added to blk_-6308508598639278892 size 67108864
+081111 090818 25109 INFO dfs.DataNode$DataXceiver: Receiving block blk_6585429064641693815 src: /10.250.10.6:38158 dest: /10.250.10.6:50010
+081111 091002 25162 INFO dfs.DataNode$PacketResponder: Received block blk_6000837850922531821 of size 67108864 from /10.251.197.226
+081111 091027 25209 INFO dfs.DataNode$PacketResponder: Received block blk_7330803663603700184 of size 67108864 from /10.251.42.246
+081111 091200 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand8/_temporary/_task_200811101024_0015_m_000480_0/part-00480. blk_-5613694521084380933
+081111 091244 19683 INFO dfs.DataNode$DataXceiver: Receiving block blk_-4967783186426171722 src: /10.251.39.192:57105 dest: /10.251.39.192:50010
+081111 091317 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.11.100:50010 is added to blk_-1970947032352756307 size 67108864
+081111 091351 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand8/_temporary/_task_200811101024_0015_m_000737_0/part-00737. blk_5894088883762961800
+081111 091439 25116 INFO dfs.DataNode$DataXceiver: Receiving block blk_-4861262918414696307 src: /10.251.198.196:34168 dest: /10.251.198.196:50010
+081111 091555 25051 INFO dfs.DataNode$DataXceiver: Receiving block blk_2583600095045026513 src: /10.250.15.67:59629 dest: /10.250.15.67:50010
+081111 091647 25353 INFO dfs.DataNode$PacketResponder: Received block blk_7872746846750105239 of size 67108864 from /10.251.43.21
+081111 091728 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.39.160:50010 is added to blk_-3510473878877779134 size 67108864
+081111 091733 19 INFO dfs.FSNamesystem: BLOCK* ask 10.251.126.5:50010 to delete  blk_-9016567407076718172 blk_-8695715290502978219 blk_-7168328752988473716 blk_-4355192005224403537 blk_-3757501769775889193 blk_-154600013573668394 blk_167132135416677587 blk_2654596473569751784 blk_5202581916713319258
+081111 091742 19 INFO dfs.FSDataset: Deleting block blk_-2808875502459981198 file /mnt/hadoop/dfs/data/current/subdir3/blk_-2808875502459981198
+081111 091837 24935 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_34905976850091068 terminating
+081111 092003 25315 INFO dfs.DataNode$PacketResponder: Received block blk_4774383661473695119 of size 67108864 from /10.251.110.68
+081111 092023 25367 INFO dfs.DataNode$DataXceiver: Receiving block blk_465845235850106928 src: /10.251.70.112:39499 dest: /10.251.70.112:50010
+081111 092213 25595 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_8882415653769775762 terminating
+081111 092239 25403 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_4207359722112667226 terminating
+081111 092311 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand8/_temporary/_task_200811101024_0015_m_000882_0/part-00882. blk_-3152434225121092058
+081111 092425 25331 INFO dfs.DataNode$DataXceiver: Receiving block blk_4820650745157199554 src: /10.251.127.243:49726 dest: /10.251.127.243:50010
+081111 092436 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.6.223:50010 is added to blk_-6390296685077811803 size 3546314
+081111 092617 19 INFO dfs.FSDataset: Deleting block blk_9173199815015538212 file /mnt/hadoop/dfs/data/current/subdir24/blk_9173199815015538212
+081111 092649 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand8/_temporary/_task_200811101024_0015_m_001033_0/part-01033. blk_-8948316319329891645
+081111 092720 27 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.42.207:50010 is added to blk_-6314365697827006048 size 67108864
+081111 092751 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand8/_temporary/_task_200811101024_0015_m_000939_0/part-00939. blk_-3522956055443924791
+081111 092821 25409 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_5454423648092670683 terminating
+081111 092915 25283 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_4565822428702518889 terminating
+081111 093026 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.29.239:50010 is added to blk_-409558225151784282 size 67108864
+081111 093208 25332 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-3967261531426400230 terminating
+081111 093316 25596 INFO dfs.DataNode$DataXceiver: Receiving block blk_-4655280636272058732 src: /10.251.26.8:48892 dest: /10.251.26.8:50010
+081111 093350 25537 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_-5799866343936729403 terminating
+081111 093407 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand8/_temporary/_task_200811101024_0015_m_001294_0/part-01294. blk_4214952053910973364
+081111 093429 25813 INFO dfs.DataNode$DataXceiver: Receiving block blk_-6135061626100136978 src: /10.251.31.180:48900 dest: /10.251.31.180:50010
+081111 093513 25793 INFO dfs.DataNode$DataXceiver: Receiving block blk_-5057534532247887258 src: /10.250.5.237:45766 dest: /10.250.5.237:50010
+081111 093550 25550 INFO dfs.DataNode$PacketResponder: Received block blk_9103049989653819836 of size 67108864 from /10.250.10.223
+081111 093657 25789 INFO dfs.DataNode$DataXceiver: Receiving block blk_-4365612131648152536 src: /10.251.107.227:57736 dest: /10.251.107.227:50010
+081111 093701 24237 INFO dfs.DataNode$DataXceiver: Receiving block blk_3598226258881465924 src: /10.251.199.159:41752 dest: /10.251.199.159:50010
+081111 093703 25622 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_3378157549705391333 terminating
+081111 093742 13 INFO dfs.DataBlockScanner: Verification succeeded for blk_-8347949825960763812
+081111 093814 25929 INFO dfs.DataNode$PacketResponder: Received block blk_-2934265883100282310 of size 67108864 from /10.251.39.144
+081111 093823 25642 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_1259893634804870815 terminating
+081111 093913 25312 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_412956398445037066 terminating
+081111 093952 25849 INFO dfs.DataNode$PacketResponder: Received block blk_-9167880724995702718 of size 67108864 from /10.251.214.225
+081111 094008 26005 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7764040409370932316 src: /10.251.125.237:58496 dest: /10.251.125.237:50010
+081111 094052 25242 INFO dfs.DataNode$DataXceiver: Receiving block blk_931297048899943584 src: /10.251.67.113:54324 dest: /10.251.67.113:50010
+081111 094221 25770 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_2833019093942278701 terminating
+081111 094319 25340 INFO dfs.DataNode$PacketResponder: Received block blk_-5785220384376578831 of size 67108864 from /10.251.203.80
+081111 094331 26028 INFO dfs.DataNode$PacketResponder: Received block blk_3386670145292909259 of size 67108864 from /10.251.110.68
+081111 094415 25901 INFO dfs.DataNode$DataXceiver: Receiving block blk_1859772752119590543 src: /10.251.42.246:57741 dest: /10.251.42.246:50010
+081111 094439 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand8/_temporary/_task_200811101024_0015_m_001425_0/part-01425. blk_2630223487595425525
+081111 094633 25926 INFO dfs.DataNode$PacketResponder: Received block blk_-5385105076403314787 of size 67108864 from /10.251.42.9
+081111 094713 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand8/_temporary/_task_200811101024_0015_m_001757_0/part-01757. blk_-5343533992609553091
+081111 094825 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand8/_temporary/_task_200811101024_0015_m_001473_0/part-01473. blk_-4390972361898978900
+081111 094832 26039 INFO dfs.DataNode$PacketResponder: Received block blk_1190791818440776717 of size 67108864 from /10.251.43.147
+081111 094918 25951 INFO dfs.DataNode$PacketResponder: Received block blk_-7202857144668308473 of size 67108864 from /10.251.43.21
+081111 094921 25993 INFO dfs.DataNode$DataXceiver: Receiving block blk_5565611615515783341 src: /10.251.126.5:35656 dest: /10.251.126.5:50010
+081111 094930 26178 INFO dfs.DataNode$PacketResponder: Received block blk_-3283153974358895314 of size 67108864 from /10.251.111.228
+081111 094936 25537 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-1484647023667047838 terminating
+081111 094939 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.6.223:50010 is added to blk_7474737521119026445 size 67108864
+081111 095020 25962 INFO dfs.DataNode$DataXceiver: Receiving block blk_-8571819028995448536 src: /10.251.197.226:34801 dest: /10.251.197.226:50010
+081111 095035 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.214.67:50010 is added to blk_-8428590803682810851 size 67108864
+081111 095039 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/rand8/_temporary/_task_200811101024_0015_m_001860_0/part-01860. blk_8716294289715825928
+081111 095238 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.123.132:50010 is added to blk_8527475857502481768 size 67108864
+081111 095309 26010 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_406835586147450451 terminating
+081111 095434 26090 INFO dfs.DataNode$PacketResponder: Received block blk_7294821275446427348 of size 67108864 from /10.251.43.210
+081111 095535 28 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.127.243:50010 is added to blk_1793140687921032046 size 67108864
+081111 095618 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.126.5:50010 is added to blk_4361294871479973840 size 67108864
+081111 095632 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.6.4:50010 is added to blk_-6945615463687647586 size 67108864
+081111 095636 26319 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_1216611589160220108 terminating
+081111 095653 25890 INFO dfs.DataNode$DataXceiver: Receiving block blk_-3265479347842446682 src: /10.250.14.224:47278 dest: /10.250.14.224:50010
+081111 095702 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.10.6:50010 is added to blk_8527562124953828227 size 67108864
+081111 095726 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.30.134:50010 is added to blk_2749066163012162435 size 67108864
+081111 095733 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.111.228:50010 is added to blk_-1305222006484630743 size 67108864
+081111 095813 26362 INFO dfs.DataNode$PacketResponder: Received block blk_-3702595599317472079 of size 67108864 from /10.251.25.237
+081111 095840 26225 INFO dfs.DataNode$PacketResponder: Received block blk_6446927133528675675 of size 67108864 from /10.251.39.209
+081111 095844 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.215.192:50010 is added to blk_2015610615789582788 size 67108864
+081111 095957 26 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.75.49:50010 is added to blk_-2959268996938658555 size 15715490
+081111 100210 19 INFO dfs.FSDataset: Deleting block blk_-1082541280306680938 file /mnt/hadoop/dfs/data/current/subdir38/blk_-1082541280306680938
+081111 100223 26181 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-191333338640084691 terminating
+081111 100226 26261 INFO dfs.DataNode$DataXceiver: Receiving block blk_3972778210951456006 src: /10.251.121.224:56526 dest: /10.251.121.224:50010
+081111 100245 26152 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_1408672604432845193 terminating
+081111 100323 14118 INFO dfs.DataNode$PacketResponder: Received block blk_7679838117000095334 of size 67108864 from /10.251.30.85
+081111 100350 32 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.250.13.240:50010 is added to blk_2593937801738981947 size 67108864
+081111 100414 35 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.71.193:50010 is added to blk_5489815612272797790 size 67108864
+081111 100417 30 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.30.101:50010 is added to blk_6451403582950672007 size 67108864
+081111 100646 26268 INFO dfs.DataNode$DataXceiver: Receiving block blk_-7048088870427586736 src: /10.250.10.100:56512 dest: /10.250.10.100:50010
+081111 100729 26320 INFO dfs.DataNode$PacketResponder: Received block blk_7589872946955471867 of size 67108864 from /10.251.195.70
+081111 100752 26527 INFO dfs.DataNode$DataXceiver: Receiving block blk_-178934379749864379 src: /10.251.71.97:55517 dest: /10.251.71.97:50010
+081111 100820 26329 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_2026200052147887341 terminating
+081111 100824 26391 INFO dfs.DataNode$DataXceiver: Receiving block blk_8303284829424905326 src: /10.251.70.37:47359 dest: /10.251.70.37:50010
+081111 100903 33 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.111.130:50010 is added to blk_5646792755154529338 size 67108864
+081111 101115 26281 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_712730845180531820 terminating
+081111 101117 26526 INFO dfs.DataNode$PacketResponder: PacketResponder 2 for block blk_8418106412701718933 terminating
+081111 101120 31 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.67.225:50010 is added to blk_-6325232815283133921 size 67108864
+081111 101131 26402 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-800664075087524591 terminating
+081111 101153 26436 INFO dfs.DataNode$PacketResponder: Received block blk_6516880861186877710 of size 67108864 from /10.251.42.84
+081111 101206 26380 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-3228470001178394592 terminating
+081111 101225 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.allocateBlock: /user/root/randtxt9/_temporary/_task_200811101024_0016_m_000347_0/part-00347. blk_-8426741581316629266
+081111 101230 34 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.29.239:50010 is added to blk_-762982068597249045 size 67108864
+081111 101238 26399 INFO dfs.DataNode$DataXceiver: Receiving block blk_-5224756755359850354 src: /10.251.43.192:38028 dest: /10.251.43.192:50010
+081111 101243 26312 INFO dfs.DataNode$PacketResponder: Received block blk_-1440254020029439248 of size 67108864 from /10.251.30.85
+081111 101316 29 INFO dfs.FSNamesystem: BLOCK* NameSystem.addStoredBlock: blockMap updated: 10.251.90.64:50010 is added to blk_1441315972355360459 size 67108864
+081111 101356 26434 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_-9001895211102825241 terminating
+081111 101415 26449 INFO dfs.DataNode$PacketResponder: PacketResponder 1 for block blk_-2025617675484194470 terminating
+081111 101444 26469 INFO dfs.DataNode$PacketResponder: Received block blk_-1592043549272047369 of size 67108864 from /10.251.105.189
+081111 101455 26895 INFO dfs.DataNode$DataXceiver: Receiving block blk_2583125615128303019 src: /10.251.71.97:54431 dest: /10.251.71.97:50010
+081111 101621 24902 INFO dfs.DataNode$DataXceiver: Receiving block blk_4198733391373026104 src: /10.251.106.10:46843 dest: /10.251.106.10:50010
+081111 101735 26595 INFO dfs.DataNode$PacketResponder: Received block blk_-5815145248455404269 of size 67108864 from /10.251.121.224
+081111 101804 26494 INFO dfs.DataNode$DataXceiver: Receiving block blk_-295306975763175640 src: /10.250.9.207:53270 dest: /10.250.9.207:50010
+081111 101954 26414 INFO dfs.DataNode$PacketResponder: PacketResponder 0 for block blk_5225719677049010638 terminating
+081111 102017 26347 INFO dfs.DataNode$DataXceiver: Receiving block blk_4343207286455274569 src: /10.250.9.207:59759 dest: /10.250.9.207:50010


### PR DESCRIPTION
This implementation keeps track of the trained tree and logCluL with `pickle`. Templates will keep being updated but old logs are not. There's also training history backup in case anything goes wrong.