### PR TITLE
fix: 调整re处理正则方式以兼容python3.7.4

### DIFF
--- a/logparser/Drain/Drain.py
+++ b/logparser/Drain/Drain.py
@@ -6,6 +6,7 @@ License     : MIT
 
 import re
 import os
+from sys import version_info
 import numpy as np
 import pandas as pd
 import hashlib
@@ -336,7 +337,10 @@ class LogParser:
         template_regex = re.sub(r"<.{1,5}>", "<*>", row["EventTemplate"])
         if "<*>" not in template_regex: return []
         template_regex = re.sub(r'([^A-Za-z0-9])', r'\\\1', template_regex)
-        template_regex = re.sub(r'\\ +', r'\s+', template_regex)
+        if version_info.major == 2: # 判断python主版本
+            template_regex = re.sub(r'\\ +', r'\s+', template_regex)
+        else:
+            template_regex = re.sub(r'\\', r'', template_regex)
         template_regex = "^" + template_regex.replace("\<\*\>", "(.*?)") + "$"
         parameter_list = re.findall(template_regex, row["Content"])
         parameter_list = parameter_list[0] if parameter_list else ()

--- a/logparser/Drain/Drain.py
+++ b/logparser/Drain/Drain.py
@@ -340,9 +340,11 @@ class LogParser:
         if version_info.major == 2: # 判断python主版本
             template_regex = re.sub(r'\\ +', r'\s+', template_regex)
         else:
-            template_regex = re.sub(r'\\', r'', template_regex)
+            template_regex = re.sub(r'\\ ', r' ', template_regex)
         template_regex = "^" + template_regex.replace("\<\*\>", "(.*?)") + "$"
+        print(template_regex)
         parameter_list = re.findall(template_regex, row["Content"])
         parameter_list = parameter_list[0] if parameter_list else ()
         parameter_list = list(parameter_list) if isinstance(parameter_list, tuple) else [parameter_list]
+        print(parameter_list)
         return parameter_list

--- a/logparser/Drain/Drain.py
+++ b/logparser/Drain/Drain.py
@@ -342,9 +342,7 @@ class LogParser:
         else:
             template_regex = re.sub(r'\\ ', r' ', template_regex)
         template_regex = "^" + template_regex.replace("\<\*\>", "(.*?)") + "$"
-        print(template_regex)
         parameter_list = re.findall(template_regex, row["Content"])
         parameter_list = parameter_list[0] if parameter_list else ()
         parameter_list = list(parameter_list) if isinstance(parameter_list, tuple) else [parameter_list]
-        print(parameter_list)
         return parameter_list


### PR DESCRIPTION
Drain在python3.7.4环境下运行报错，
`error: bad escape \s at position 0 `
故做一下兼容处理。