### PR TITLE
Added cleanData() and modified Spell_demo

### DIFF
--- a/demo/Spell_demo.py
+++ b/demo/Spell_demo.py
@@ -3,12 +3,13 @@ import sys
 sys.path.append('../')
 from logparser import Spell
 
-input_dir  = '../logs/HDFS/'  # The input directory of log file
-output_dir = 'Spell_result/'  # The output directory of parsing results
-log_file   = 'HDFS_2k.log'  # The input log file name
-log_format = '<Date> <Time> <Pid> <Level> <Component>: <Content>'  # HDFS log format
-tau        = 0.5  # Message type threshold (default: 0.5)
-regex      = []  # Regular expression list for optional preprocessing (default: [])
+input_dir  = '../logs/f/'  # The input directory of log file
+output_dir = 'f_result/'  # The output directory of parsing results
+log_file   = 'result.log'  # The input log file name
+log_format = "<Date> <Time> <Type> <Component> <Content>"
+tau        = 0.3  # Message type threshold (default: 0.5)
+regex      = ["::(.*)"]  # Regular expression list for optional preprocessing (default: [])
+regex_remove = ['-{2,99}',"/\s\s+/g,"] # Regular expression list for removing certain patterns from the data before Spell starts (for example remove multiple ":" or remove multiple spaces including tabs)
 
-parser = Spell.LogParser(indir=input_dir, outdir=output_dir, log_format=log_format, tau=tau, rex=regex)
+parser = Spell.LogParser(input_dir, output_dir, log_format, tau, regex, regex_remove=regex_remove)
 parser.parse(log_file)

--- a/logparser/Spell/Spell.py
+++ b/logparser/Spell/Spell.py
@@ -233,9 +233,11 @@ class LogParser:
         logCluL = []
 
         count = 0
+        f = open("file.txt", "w")
         for idx, line in self.df_log.iterrows():
             logID = line['LineId']
             logmessageL = list(filter(lambda x: x != '', re.split(r'[\s=:,]', self.preprocess(line['Content']))))
+            f.write(str(line))
             constLogMessL = [w for w in logmessageL if w != '<*>']
 
             #Find an existing matched log cluster
@@ -271,6 +273,7 @@ class LogParser:
 
         self.outputResult(logCluL)
         print('Parsing done. [Time taken: {!s}]'.format(datetime.now() - starttime))
+        f.close()
 
     def load_data(self):
         headers, regex = self.generate_logformat_regex(self.logformat)


### PR DESCRIPTION
In Spell_Demo you can specify a list of regex_remove expressions (just like you do with the preprocessing). This list will be used to pre clean the data before the Spell algorithm starts. For example, pytest logs can contain strings such as "-----" or multiple ":" characters. These seem to confuse Spell and it treats some of them as parameters therefore leading to real parameters not being parsed. 

I think this might be useful if developers know already some "noise" patterns that appear in the logs and want to remove them