### PR TITLE
Logmatch : Resolve matching with n_workers greater than 1

### DIFF
--- a/logparser/logmatch/regexmatch.py
+++ b/logparser/logmatch/regexmatch.py
@@ -76,7 +76,7 @@ class RegexMatch:
             results = match_fn(event_list, self.template_match_dict, self.optimized)
         else:
             pool = mp.Pool(processes=self.n_workers)
-            chunk_size = len(event_list) / self.n_workers + 1
+            chunk_size = len(event_list) // self.n_workers + 1
             result_chunks = [
                 pool.apply_async(
                     match_fn,
@@ -86,7 +86,7 @@ class RegexMatch:
                         self.optimized,
                     ),
                 )
-                for i in xrange(0, len(event_list), chunk_size)
+                for i in range(0, len(event_list), chunk_size)
             ]
             pool.close()
             pool.join()


### PR DESCRIPTION
When logmatch is tested with n_workers greater than 1, the error is outputed that xrange is depracated and chunk_size being float type.
Commit resolves the data type issue and also changes xrange to range
<img width="503" alt="Screenshot 2023-11-29 at 22 13 53" src="https://github.com/logpai/logparser/assets/56340691/5e31c4aa-1415-4852-96a6-f7ee6ad50940">
