### PR TITLE
Fixed a potential bugs that may lead to positional misalignment between pred and gt on different device.

### DIFF
--- a/logparser/DivLog/README.md
+++ b/logparser/DivLog/README.md
@@ -40,6 +40,22 @@ If you wish to re-run all the results (which may cost much time and api budget),
 rm -r results
 ```
 
+#### Attention:
+
+OpenAI has [shut down](https://platform.openai.com/docs/deprecations/2023-07-06-gpt-and-embeddings) the *Text Completion API* for the GPT-3 model series (`ada`,`babbage`,`curie`,`davinci`) as of January 4th, 2024. If you wish to apply the DivLog framework on other OpenAI *Chat Completion APIs* and re-run all the results, you may need to modify the API request in `BatchParse` of `DivLog.py`. Specifically, you need to replace the original API request design for GPT-3 models with the latest Chat Completion API:
+
+```python
+### Replace it
+response = openai.Completion.create(
+                                    model=model, 
+                                    prompt=instruction + "\n\n\n" + prompt + "<prompt>:" + line.strip() + "\n<extraction>: ", 
+                                    temperature=temperature,
+                                    max_tokens=token_len)
+```
+
+More details about APIs can be found [here](https://platform.openai.com/docs/api-reference/chat).
+
+
 ### Benchmark
 
 Running the benchmark script on Loghub_2k datasets, you could obtain the following results.


### PR DESCRIPTION
In the existing version, when DivLog performs an evaluation on the current results, it reorders "gt" according to the DPP algorithm. However, the DPP algorithm is implemented using the `math` library. We discovered that the computation results for DPP vary across different versions of Python, which subsequently leads to changes in the order of "gt". 

To be more specific, if the parsed results are generated on device A, and the comparison with "gt" for evaluation is also conducted on device A, then the evaluation results are accurate. That's because both processes are operated on device A, thus ensuring the same DPP rearrangement order. However, if the results are generated on device A, but compared with "gt" on device B, the orders of results and "gt" may be misaligned, leading to incorrect evaluation results. This is due to the variations in DPP outcomes between the two devices, resulting in inconsistencies between the orders of samples in results and "gt".

To resolve this issue, the current update abandons ordered one-to-one evaluation according to the post-DPP mapping. Instead, it assesses based on whether the corresponding result and "gt" for each original log message are consistent. The current evaluation method has been corrected.

Additionally, in this update, we've added a notice of GPT-3's deprecation to the README.md.