### PR TITLE
Fixed CSV writing issue in Brain Algorithm: Added `escapechar` and `quoting` options for datasets with special characters

### DIFF
--- a/logparser/Brain/Brain.py
+++ b/logparser/Brain/Brain.py
@@ -106,8 +106,12 @@ class LogParser:
 
         self.df_log["EventId"] = EventID
         self.df_log["EventTemplate"] = template_
+        
         self.df_log.to_csv(
-            os.path.join(self.savePath, self.logName + "_structured.csv"), index=False
+            os.path.join(self.savePath, self.logName + "_structured.csv"), 
+            index=False,
+            escapechar="\\",
+            quoting=1
         )
 
         df_event = pd.DataFrame(
@@ -117,6 +121,8 @@ class LogParser:
             os.path.join(self.savePath, self.logName + "_templates.csv"),
             index=False,
             columns=["EventId", "EventTemplate", "Occurrences"],
+            escapechar="\\",
+            quoting=1
         )
 
     def preprocess(self, line):


### PR DESCRIPTION
#### Problem:
This PR addresses an issue in the `Brain` module when writing structured log data to a CSV file. The error encountered is:

```
Error: need to escape, but no escapechar set
```

The error occurs when parsing datasets that contain special characters or quotes. By default, `pandas.to_csv()` does not set an escape character, which leads to a failure when special characters are present in the data.

#### Solution:
The fix involves explicitly setting the following options when calling `to_csv()` in `generateresult` method of `LogParser` class:
- `escapechar='\\'`: Specifies the escape character (`\`) to handle special characters correctly.
- `quoting=1` (`csv.QUOTE_MINIMAL`): Ensures that fields containing special characters (such as commas, quotes, or newlines) are wrapped in quotes.

#### Checklist:
- [x] Code tested with large datasets containing special characters that previously caused the error.
- [x] Changes verified to be backward-compatible.
- [x] Structured logs (`_structured.csv`) and event templates (`_templates.csv`) were successfully written without encountering the `escapechar` error.