### PR TITLE
fix a small bug from Logram

### DIFF
--- a/logparser/Logram/src/Common.py
+++ b/logparser/Logram/src/Common.py
@@ -15,7 +15,7 @@ MyRegex = [
 def preprocess(logLine, specialRegex):
     line = logLine
     for regex in specialRegex:
-        line = re.sub(regex, "<*>", " " + logLine)
+        line = re.sub(regex, "<*>", " " + line)
     return line
 
 


### PR DESCRIPTION
I think there is a small typo in the code.

The preprocess function should iterate over the elements (regex) in the specialRegex array and process the logline with each regex sequentially.

Originally, the preprocess function only used the last element (regex) in specialRegex to process the logline.

After making this modification, I found that the accuracy improved significantly.